### PR TITLE
add: e2e basic tests for back-office and ci

### DIFF
--- a/.github/workflows/build-and-e2e-back-office-tests.yml
+++ b/.github/workflows/build-and-e2e-back-office-tests.yml
@@ -1,0 +1,55 @@
+name: Build and E2E back-office tests
+
+on:
+  workflow_dispatch:
+
+env:
+  NODE_OPTIONS: '--max_old_space_size=4096'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout [Pull Request]
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - uses: actions/checkout@v3
+        name: Checkout [Default Branch]
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          fetch-depth: 0
+
+      - name: Derive appropriate SHAs for base and head for nx affected commands
+        id: nx
+        uses: nrwl/nx-set-shas@v3
+        with:
+          main-branch-name: staging
+
+      - name: Set up environment and cache dependencies
+        uses: sebpalluel/ci/.github/actions/setup-environment@latest
+
+      - name: Build and check if back-office affected
+        id: check
+        run: |
+          affected=$(pnpm nx affected -t=build)
+          if [[ $affected == *"back-office:build:production"* ]]; then
+            echo "::set-output name=back-office::true"
+          else
+            echo "::set-output name=back-office::false"
+          fi
+
+      - name: Launch docker services
+        if: steps.check.outputs.back-office == 'true'
+        run: pnpm docker:services & pnpm nx run back-office:build:production
+
+      - name: Run e2e tests
+        if: steps.check.outputs.back-office == 'true'
+        run: pnpm nx run back-office:e2e --skipInstall

--- a/.github/workflows/pr-approval-trigger-preview.yml
+++ b/.github/workflows/pr-approval-trigger-preview.yml
@@ -28,3 +28,10 @@ jobs:
           workflow: Build and E2E web tests
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Trigger Build and E2E Workflow for Back-office
+        uses: benc-uk/workflow-dispatch@v1.2.2
+        with:
+          workflow: Build and E2E back-office tests
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}

--- a/apps/back-office/.eslintrc.json
+++ b/apps/back-office/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "extends": [
+    "plugin:playwright/recommended",
     "plugin:@nx/react-typescript",
     "next",
     "next/core-web-vitals",
@@ -20,6 +21,10 @@
     },
     {
       "files": ["*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["e2e/**/*.{ts,js,tsx,jsx}"],
       "rules": {}
     }
   ],

--- a/apps/back-office/e2e/humanResources.spec.ts
+++ b/apps/back-office/e2e/humanResources.spec.ts
@@ -1,3 +1,4 @@
+import { Roles_Enum } from '@gql/shared/types';
 import { expect, test } from '@playwright/test';
 import { resetCache } from '@test-utils/cache';
 import {
@@ -38,13 +39,11 @@ test.beforeEach(async () => {
 test('human resources should not have access to events', async () => {
   const { page } = await loadAccountAndRole({
     user: 'alpha_user',
-    goTo: '/fr',
-    role: 'Ressources humaines',
+    goTo: '/en',
+    role: Roles_Enum.OrganizerHumanResources,
   });
+  await expect(page.getByRole('link', { name: 'Manage Roles' })).toBeVisible();
   await expect(
-    page.getByRole('link', { name: 'Gérer les rôles' }),
-  ).toBeVisible();
-  await expect(
-    page.getByRole('link', { name: 'Event Management Gestion des' }),
+    page.getByRole('link', { name: 'Event Management' }),
   ).toBeHidden();
 });

--- a/apps/back-office/e2e/humanResources.spec.ts
+++ b/apps/back-office/e2e/humanResources.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+import { resetCache } from '@test-utils/cache';
+import {
+  PgClient,
+  applySeeds,
+  createDbClient,
+  deleteAllTables,
+} from '@test-utils/db';
+import { loadAccountAndRole } from './utils/loadAccountAndRole';
+
+let client: PgClient;
+
+test.beforeAll(async () => {
+  client = await createDbClient();
+  await deleteAllTables(client);
+  await resetCache();
+});
+
+test.afterAll(async () => {
+  await client.end();
+});
+
+test.afterEach(async () => {
+  await deleteAllTables(client);
+});
+
+test.beforeEach(async () => {
+  await applySeeds(client, [
+    'account',
+    'kyc',
+    'eventPassPricing',
+    'eventParameters',
+    'roleAssignments',
+  ]);
+});
+
+// eslint-disable-next-line playwright/expect-expect
+test('human resources should not have access to events', async () => {
+  const { page } = await loadAccountAndRole({
+    user: 'alpha_user',
+    goTo: '/fr',
+    role: 'Ressources humaines',
+  });
+  await expect(
+    page.getByRole('link', { name: 'Gérer les rôles' }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('link', { name: 'Event Management Gestion des' }),
+  ).toBeHidden();
+});

--- a/apps/back-office/e2e/superAdmin.spec.ts
+++ b/apps/back-office/e2e/superAdmin.spec.ts
@@ -1,3 +1,4 @@
+import { Roles_Enum } from '@gql/shared/types';
 import { expect, test } from '@playwright/test';
 import { resetCache } from '@test-utils/cache';
 import {
@@ -38,41 +39,29 @@ test.beforeEach(async () => {
 test('super admin should be able to view events', async () => {
   const { page } = await loadAccountAndRole({
     user: 'alpha_user',
-    goTo: '/fr',
-    role: 'Test Super Admin',
+    goTo: '/en',
+    role: Roles_Enum.OrganizerSuperAdmin,
   });
-  await page
-    .getByRole('link', { name: 'Event Management Gestion des' })
-    .click();
+  await page.getByRole('link', { name: 'Events Management' }).click();
   await expect(page.getByText('An event')).toBeVisible();
   await expect(page.getByText('test-an-event')).toBeVisible();
   await expect(
-    page.getByRole('heading', { name: 'Gestion des événements' }),
+    page.getByRole('heading', { name: 'Events Management' }),
   ).toBeVisible();
-  await expect(page.getByText('Anniversaire', { exact: true })).toBeVisible();
+  await expect(page.getByText('Anniversaire')).toBeVisible();
   await expect(page.getByText('test-anniversaire')).toBeVisible();
   await page
     .getByRole('row', { name: 'An event test-an-event' })
     .getByRole('button')
     .click();
-  await page.getByRole('link', { name: 'Edit Éditer' }).click();
-  await page.goto('http://localhost:1789/fr/events/test-an-event');
-  await page
-    .getByRole('button', { name: 'Informations sur les NFTs' })
-    .nth(1)
-    .click();
+  await page.getByRole('link', { name: 'Edit Edit' }).click();
   await expect(page.getByRole('heading', { name: 'An event' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Gold' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'VIP' })).toBeVisible();
   await expect(page.getByText('Pass vip pour le match')).toBeVisible();
   await expect(page.getByText('Pass gold pour le match')).toBeVisible();
-  await expect(page.getByText('NomDefault name for NFT').first()).toBeVisible();
-  await expect(page.getByText('DescriptionDefault NFT').first()).toBeVisible();
-  await expect(page.getByText('Quantitée20').first()).toBeVisible();
-  await expect(page.getByText('1', { exact: true })).toBeVisible();
-  await expect(page.getByText('Quantitée par utilisateur1')).toBeVisible();
   await page
-    .getByRole('button', { name: 'Pass associés à vos NFTs' })
+    .getByRole('button', { name: 'Pass associated to your NFTs' })
     .first()
     .click();
   await expect(
@@ -84,13 +73,13 @@ test('super admin should be able to view events', async () => {
       .locator('span'),
   ).toBeVisible();
   await expect(
-    page.getByRole('button', { name: 'Déployer le contrat NFTs' }).first(),
+    page.getByRole('button', { name: 'Deploy the NFTs contract' }).first(),
   ).toBeVisible();
   await expect(
     page.locator('span').filter({ hasText: '0xfake***ddress1' }).first(),
   ).toBeVisible();
   await page.getByTestId('sheet-back').click();
   await expect(
-    page.getByRole('heading', { name: 'Gestion des événements' }),
+    page.getByRole('heading', { name: 'Events Management' }),
   ).toBeVisible();
 });

--- a/apps/back-office/e2e/superAdmin.spec.ts
+++ b/apps/back-office/e2e/superAdmin.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from '@playwright/test';
+import { resetCache } from '@test-utils/cache';
+import {
+  PgClient,
+  applySeeds,
+  createDbClient,
+  deleteAllTables,
+} from '@test-utils/db';
+import { loadAccountAndRole } from './utils/loadAccountAndRole';
+
+let client: PgClient;
+
+test.beforeAll(async () => {
+  client = await createDbClient();
+  await deleteAllTables(client);
+  await resetCache();
+});
+
+test.afterAll(async () => {
+  await client.end();
+});
+
+test.afterEach(async () => {
+  await deleteAllTables(client);
+});
+
+test.beforeEach(async () => {
+  await applySeeds(client, [
+    'account',
+    'kyc',
+    'eventPassPricing',
+    'eventPassNftContract',
+    'eventParameters',
+    'roleAssignments',
+  ]);
+});
+
+test('super admin should be able to view events', async () => {
+  const { page } = await loadAccountAndRole({
+    user: 'alpha_user',
+    goTo: '/fr',
+    role: 'Test Super Admin',
+  });
+  await page
+    .getByRole('link', { name: 'Event Management Gestion des' })
+    .click();
+  await expect(page.getByText('An event')).toBeVisible();
+  await expect(page.getByText('test-an-event')).toBeVisible();
+  await expect(
+    page.getByRole('heading', { name: 'Gestion des événements' }),
+  ).toBeVisible();
+  await expect(page.getByText('Anniversaire', { exact: true })).toBeVisible();
+  await expect(page.getByText('test-anniversaire')).toBeVisible();
+  await page
+    .getByRole('row', { name: 'An event test-an-event' })
+    .getByRole('button')
+    .click();
+  await page.getByRole('link', { name: 'Edit Éditer' }).click();
+  await page.goto('http://localhost:1789/fr/events/test-an-event');
+  await page
+    .getByRole('button', { name: 'Informations sur les NFTs' })
+    .nth(1)
+    .click();
+  await expect(page.getByRole('heading', { name: 'An event' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Gold' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'VIP' })).toBeVisible();
+  await expect(page.getByText('Pass vip pour le match')).toBeVisible();
+  await expect(page.getByText('Pass gold pour le match')).toBeVisible();
+  await expect(page.getByText('NomDefault name for NFT').first()).toBeVisible();
+  await expect(page.getByText('DescriptionDefault NFT').first()).toBeVisible();
+  await expect(page.getByText('Quantitée20').first()).toBeVisible();
+  await expect(page.getByText('1', { exact: true })).toBeVisible();
+  await expect(page.getByText('Quantitée par utilisateur1')).toBeVisible();
+  await page
+    .getByRole('button', { name: 'Pass associés à vos NFTs' })
+    .first()
+    .click();
+  await expect(
+    page
+      .getByRole('cell', {
+        name: '/local/organizers/clizzky8kap2t0bw7wka9a2id/events/clizzpvidao620buvxit1ynko/clkr1vpdhnqg80bw2ckil7ytq/clizzpvidao620buvxit1ynko-clkr1vpdhnqg80bw2ckil7ytq-0.jpg',
+        exact: true,
+      })
+      .locator('span'),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Déployer le contrat NFTs' }).first(),
+  ).toBeVisible();
+  await expect(
+    page.locator('span').filter({ hasText: '0xfake***ddress1' }).first(),
+  ).toBeVisible();
+  await page.getByTestId('sheet-back').click();
+  await expect(
+    page.getByRole('heading', { name: 'Gestion des événements' }),
+  ).toBeVisible();
+});

--- a/apps/back-office/e2e/utils/alpha_user.json
+++ b/apps/back-office/e2e/utils/alpha_user.json
@@ -1,0 +1,48 @@
+{
+  "cookies": [
+    {
+      "domain": "localhost",
+      "httpOnly": false,
+      "name": "NEXT_CURRENCY",
+      "path": "/",
+      "secure": false,
+      "value": "EUR"
+    },
+    {
+      "domain": "localhost",
+      "httpOnly": false,
+      "name": "NEXT_LOCALE",
+      "path": "/",
+      "sameSite": "Strict",
+      "secure": false,
+      "value": "en"
+    },
+    {
+      "domain": "localhost",
+      "httpOnly": true,
+      "name": "next-auth.callback-url",
+      "path": "/",
+      "sameSite": "Lax",
+      "secure": false,
+      "value": "http%3A%2F%2Flocalhost%3A8888%2Fen"
+    },
+    {
+      "domain": "localhost",
+      "httpOnly": true,
+      "name": "next-auth.csrf-token",
+      "path": "/",
+      "sameSite": "Lax",
+      "secure": false,
+      "value": "6fb0054e3b25f951a473aa28c9f91ed20ecb626f0ec6e72cff6bdbdb1b11198b%7C37b1e67d598e9dff6c035184dbe93eecc651d1727916b395ab9ac13985e555f6"
+    },
+    {
+      "domain": "localhost",
+      "httpOnly": true,
+      "name": "next-auth.session-token.back-office",
+      "path": "/",
+      "sameSite": "Lax",
+      "secure": false,
+      "value": "eyJhbGciOiJSUzI1NiJ9.eyJ1c2VyIjp7ImlkIjoiNjc5ZjkyZDYtYTAxZS00YWI3LTkzZjgtMTA4NDBkMjJiMGE1IiwiYWRkcmVzcyI6IjB4Qjk4YkQ3QzdmNjU2MjkwMDcxRTUyRDFhQTYxN0Q5Y0I0NDY3RmQ2RCIsImVtYWlsIjoiYWxwaGFfdXNlckB0ZXN0LmlvIiwia3ljIjp7ImFwcGxpY2FudElkIjoiNjRkNWY3YTU4ZjI0MTE2NmQ3NTZiYTMzIiwicmV2aWV3U3RhdHVzIjoiY29tcGxldGVkIiwibGV2ZWxOYW1lIjoiYWR2YW5jZWRfa3ljX2xldmVsIn0sInJvbGVzIjpbeyJyb2xlIjoib3JnYW5pemVyX3N1cGVyX2FkbWluIiwib3JnYW5pemVySWQiOiJjbGl6emt5OGthcDJ0MGJ3N3drYTlhMmlkIiwiZXZlbnRJZCI6IiJ9LHsicm9sZSI6Im9yZ2FuaXplcl9odW1hbl9yZXNvdXJjZXMiLCJvcmdhbml6ZXJJZCI6ImNsaXp6a3k4a2FwMnQwYnc3d2thOWEyaWQiLCJldmVudElkIjoiIn0seyJyb2xlIjoib3JnYW5pemVyX29wZXJhdGlvbnNfbWFuYWdlciIsIm9yZ2FuaXplcklkIjoiY2xpenpreThrYXAydDBidzd3a2E5YTJpZCIsImV2ZW50SWQiOiIifV19LCJyb2xlIjoidXNlciJ9.psjf9S-UPnR0AM2sU-8lixcDdJC874y-Lz7vkRb5Eb0vr43rSUdtIgbz9TkngpRVJDI__LAuN54admlFXI72dFiH90FO_SI6zwKC5sFQcKYtWnLgoTC1HLYJTbWTl70e7wNZ10cwfGvcISErLuce03V9oAUgCqx5izGjhlD7BihItrljJ9we1wDuRip0P2d_DVMMxtWRpd-sd-Ki2-yOk8X53KYR-GyHA92TDifE_FUUhzieKONGQUrTFWcw7ESUsAxOkRvG5HkixZ9nuriqR9Kn4KUte2tU-c9A6K-nVpl9OlGHnfv7S5zRMEkDuElH6IhMPIXie_gUs_yjx977sDJPi4e8xWzWej1z2JeqilbSc_kp-dF5GQae-eZc6WHDaWqDgTbqkZNsUluQjDJM7-PC3GNCNgYPqoxpdusuVzlvs9tQRaFqaSR3tV5gv28CxJ6gQQC5czQFSy-Tkli4BUCAo0CesChvomKk-8oa0Hn7cDUWNUU7CzTokxW9YQG6F6JweBNsCNuQRxfvLl2bS2xYUlbZrB-8FXKFVfI83CW8s5NIEVGdTt8cx-p_fmqHHLJWa5B4jKAmNdpi2lJ0fyyN4vA0r6TCGp2b9ORNtFVeEfPsYGSvt8MuZQzkBtpHBEi3IHIm7oxrZoZpDVyV8ySHfTrIyfw52ZiE92KcMvw"
+    }
+  ]
+}

--- a/apps/back-office/e2e/utils/loadAccountAndRole.ts
+++ b/apps/back-office/e2e/utils/loadAccountAndRole.ts
@@ -1,3 +1,5 @@
+import { Roles_Enum } from '@gql/shared/types';
+import { getMessages } from '@next/i18n';
 import { AppUser } from '@next/types';
 import { expect } from '@playwright/test';
 import { accounts } from '@test-utils/gql';
@@ -6,14 +8,39 @@ import { chromium } from 'playwright';
 interface LoadUserProps {
   user: keyof typeof accounts;
   goTo?: string;
-  role: string;
+  role: Roles_Enum;
 }
+
+let roleNames: { [key in Roles_Enum]?: string };
 
 export async function loadAccountAndRole({
   user,
   goTo = '/en',
   role,
 }: LoadUserProps) {
+  const englishMessages = await getMessages('en');
+
+  roleNames = {
+    [Roles_Enum.OrganizerAdmin]:
+      englishMessages.Roles.RoleBadge['organizer-admin'],
+    [Roles_Enum.OrganizerAuditor]:
+      englishMessages.Roles.RoleBadge['organizer-auditor'],
+    [Roles_Enum.OrganizerContentManager]:
+      englishMessages.Roles.RoleBadge['organizer-content-manager'],
+    [Roles_Enum.OrganizerFinanceManager]:
+      englishMessages.Roles.RoleBadge['organizer-finance-manager'],
+    [Roles_Enum.OrganizerGuest]:
+      englishMessages.Roles.RoleBadge['organizer-guest'],
+    [Roles_Enum.OrganizerHumanResources]:
+      englishMessages.Roles.RoleBadge['organizer-human-resources'],
+    [Roles_Enum.OrganizerOperationsManager]:
+      englishMessages.Roles.RoleBadge['organizer-operations-manager'],
+    [Roles_Enum.OrganizerSuperAdmin]:
+      englishMessages.Roles.RoleBadge['organizer-super-admin'],
+    [Roles_Enum.OrganizerValidator]:
+      englishMessages.Roles.RoleBadge['organizer-validator'],
+  };
+
   const browser = await chromium.launch();
   const context = await browser.newContext({
     storageState: `apps/back-office/e2e/utils/${user as string}.json`,
@@ -42,6 +69,10 @@ export async function loadAccountAndRole({
     page.getByRole('button', { name: account.email, exact: true }),
   ).toBeVisible();
   await page.getByRole('button', { name: account.email, exact: true }).click();
-  await page.getByRole('menuitem', { name: role }).click();
+  const roleName = roleNames[role];
+  if (!roleName) {
+    throw new Error(`Role name not found for role: ${role}`);
+  }
+  await page.getByText(roleName).click();
   return { page, account };
 }

--- a/apps/back-office/e2e/utils/loadAccountAndRole.ts
+++ b/apps/back-office/e2e/utils/loadAccountAndRole.ts
@@ -1,0 +1,47 @@
+import { AppUser } from '@next/types';
+import { expect } from '@playwright/test';
+import { accounts } from '@test-utils/gql';
+import { chromium } from 'playwright';
+
+interface LoadUserProps {
+  user: keyof typeof accounts;
+  goTo?: string;
+  role: string;
+}
+
+export async function loadAccountAndRole({
+  user,
+  goTo = '/en',
+  role,
+}: LoadUserProps) {
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    storageState: `apps/back-office/e2e/utils/${user as string}.json`,
+  });
+  const page = await context.newPage();
+  const account: AppUser = accounts[user];
+  await page.exposeFunction('useE2EAuthContext', () => {
+    return JSON.stringify({
+      safeUser: {
+        eoa: account.address,
+        safes: [],
+        email: account.email,
+        profileImage: 'https://robohash.org/johndoe.png?size=96x96',
+      },
+      safeAuth: 'safeAuth',
+      provider: 'provider',
+      login: () => null,
+      logout: () => null,
+      loginSiwe: () => null,
+      logoutSiwe: () => null,
+      connecting: false,
+    });
+  });
+  await page.goto(goTo);
+  await expect(
+    page.getByRole('button', { name: account.email, exact: true }),
+  ).toBeVisible();
+  await page.getByRole('button', { name: account.email, exact: true }).click();
+  await page.getByRole('menuitem', { name: role }).click();
+  return { page, account };
+}

--- a/apps/back-office/jest.config.ts
+++ b/apps/back-office/jest.config.ts
@@ -19,4 +19,5 @@ export default {
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/apps/back-office',
+  testPathIgnorePatterns: ['/node_modules/', '/e2e/'],
 };

--- a/apps/back-office/playwright.config.ts
+++ b/apps/back-office/playwright.config.ts
@@ -1,0 +1,39 @@
+import { nxE2EPreset } from '@nx/playwright/preset';
+import { defineConfig } from '@playwright/test';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
+// For CI, you may want to set BASE_URL to the deployed application.
+const baseURL = process.env['BASE_URL'] || 'http://localhost:1789';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  ...nxE2EPreset(__filename, { testDir: './e2e' }),
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    baseURL,
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'pnpm nx run back-office:serve:production --turbo',
+    url: 'http://127.0.0.1:1789',
+    reuseExistingServer: !process.env.CI,
+    cwd: './',
+    timeout: 120000,
+  },
+  projects: [
+    {
+      name: 'Chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+  workers: 1,
+});

--- a/apps/back-office/project.json
+++ b/apps/back-office/project.json
@@ -136,6 +136,13 @@
       "options": {
         "command": "test-storybook -c apps/back-office/.storybook --url=http://localhost:4403"
       }
+    },
+    "e2e": {
+      "executor": "@nx/playwright:playwright",
+      "outputs": ["{workspaceRoot}/dist/.playwright/apps/back-office"],
+      "options": {
+        "config": "apps/back-office/playwright.config.ts"
+      }
     }
   },
   "tags": []

--- a/hasura/app/seeds/default/11_roleAssignments.sql
+++ b/hasura/app/seeds/default/11_roleAssignments.sql
@@ -2,5 +2,6 @@ SET check_function_bodies = false;
 
 INSERT INTO "public"."roleAssignments" (id, "accountId", "invitedById", role, "organizerId", "eventId", created_at) VALUES 
 ('02e75f94-c685-44ac-a2b3-6ff67feec05b', '679f92d6-a01e-4ab7-93f8-10840d22b0a5', '679f92d6-a01e-4ab7-93f8-10840d22b0a5', 'organizer_super_admin', 'clizzky8kap2t0bw7wka9a2id', '', '2023-11-04T17:11:48.978089+00:00'),
-('c2ec94e6-ec58-419c-b721-f5f8605f1df5', '679f92d6-a01e-4ab7-93f8-10840d22b0a5', '679f92d6-a01e-4ab7-93f8-10840d22b0a5', 'organizer_admin', 'dummy', '', '2023-11-04T17:12:25.562633+00:00'),
+('c2ec94e6-ec58-419c-b721-f5f8605f1df5', '679f92d6-a01e-4ab7-93f8-10840d22b0a5', '679f92d6-a01e-4ab7-93f8-10840d22b0a5', 'organizer_human_resources', 'clizzky8kap2t0bw7wka9a2id', '', '2023-11-04T17:12:25.562633+00:00'),
+('c2ec94e6-ec58-419c-b721-f5f8605f1df5', '679f92d6-a01e-4ab7-93f8-10840d22b0a5', '679f92d6-a01e-4ab7-93f8-10840d22b0a5', 'organizer_operations_manager', 'clizzky8kap2t0bw7wka9a2id', '', '2023-11-04T17:12:25.562633+00:00'),
 ('fd0d3f68-8177-4be0-bbb7-5be0deb452cd', '76189546-6368-4325-8aad-220e03837b7e', '679f92d6-a01e-4ab7-93f8-10840d22b0a5', 'organizer_admin', 'clizzky8kap2t0bw7wka9a2id', '', '2023-11-04T17:12:48.608583+00:00');

--- a/hasura/app/seeds/default/1_kyc.sql
+++ b/hasura/app/seeds/default/1_kyc.sql
@@ -1,3 +1,3 @@
 SET check_function_bodies = false;
-INSERT INTO public.kyc ("applicantId", "externalUserId", "createDate", "reviewStatus", "levelName", updated_at) VALUES ('64d5f7a58f241166d756ba33', '679f92d6-a01e-4ab7-93f8-10840d22b0a5', '2023-09-19 16:08:38+00', 'completed', 'basic_kyc_level', '2023-09-19 16:09:08.540391+00');
+INSERT INTO public.kyc ("applicantId", "externalUserId", "createDate", "reviewStatus", "levelName", updated_at) VALUES ('64d5f7a58f241166d756ba33', '679f92d6-a01e-4ab7-93f8-10840d22b0a5', '2023-09-19 16:08:38+00', 'completed', 'advanced_kyc_level', '2023-09-19 16:09:08.540391+00');
 INSERT INTO public.kyc ("applicantId", "externalUserId", "createDate", "reviewStatus", "levelName", updated_at) VALUES ('74d4f7e59f241066d756ca30', '76189546-6368-4325-8aad-220e03837b7e', '2023-09-19 16:09:31+00', 'pending', 'basic_kyc_level', '2023-09-19 16:10:13.415191+00');

--- a/libs/nft/thirdweb-organizer/src/index.ts
+++ b/libs/nft/thirdweb-organizer/src/index.ts
@@ -23,7 +23,7 @@ class NftCollection {
     const web3Provider = new ethers.providers.Web3Provider(provider);
     const signer = web3Provider.getSigner();
     this.sdk = ThirdwebSDK.fromSigner(signer, env.NEXT_PUBLIC_CHAIN, {
-      clientId: '3ce7c20950e008cb1d6138a4a06d7e7f',
+      clientId: env.NEXT_PUBLIC_THIRDWEB_CLIENT_ID,
       gasless: {
         openzeppelin: {
           relayerUrl: env.NEXT_PUBLIC_OPENZEPPELIN_URL,


### PR DESCRIPTION
## Type
Tests, Enhancement

___
## Description
This PR introduces end-to-end tests for the back-office application and integrates them into the CI workflow. The main changes include:
- Addition of E2E tests for 'humanResources' and 'superAdmin' roles in the back-office application.
- Creation of a utility function to load user accounts and roles for testing.
- Configuration of Playwright for E2E testing.
- Addition of a new GitHub Actions workflow for building and running E2E tests for the back-office application.
- Update of the ESLint configuration to include the Playwright plugin.
- Modification of the role assignments and KYC level in the Hasura seeds.

___
## Main files walkthrough
<details> <summary>files:</summary>

- `apps/back-office/e2e/humanResources.spec.ts`: Added E2E tests for the 'humanResources' role in the back-office application.
- `apps/back-office/e2e/superAdmin.spec.ts`: Added E2E tests for the 'superAdmin' role in the back-office application.
- `apps/back-office/e2e/utils/loadAccountAndRole.ts`: Created a utility function to load user accounts and roles for testing.
- `apps/back-office/playwright.config.ts`: Configured Playwright for E2E testing.
- `.github/workflows/build-and-e2e-back-office-tests.yml`: Added a new GitHub Actions workflow for building and running E2E tests for the back-office application.
- `apps/back-office/.eslintrc.json`: Updated the ESLint configuration to include the Playwright plugin.
- `hasura/app/seeds/default/11_roleAssignments.sql`: Modified the role assignments in the Hasura seeds.
- `hasura/app/seeds/default/1_kyc.sql`: Modified the KYC level in the Hasura seeds.
</details>
