### PR TITLE
192 ticket pk 02 develop packnftcontract model

### DIFF
--- a/hasura/app/metadata/databases/default/tables/public_eventPassNft.yaml
+++ b/hasura/app/metadata/databases/default/tables/public_eventPassNft.yaml
@@ -41,6 +41,9 @@ object_relationships:
         remote_table:
           name: nftTransfer
           schema: public
+  - name: packNftContract
+    using:
+      foreign_key_constraint_on: packNftContractId
 array_relationships:
   - name: nftTransfers
     using:

--- a/hasura/app/metadata/databases/default/tables/public_packNftContract.yaml
+++ b/hasura/app/metadata/databases/default/tables/public_packNftContract.yaml
@@ -1,0 +1,16 @@
+table:
+  name: packNftContract
+  schema: public
+array_relationships:
+  - name: eventPassNfts
+    using:
+      manual_configuration:
+        column_mapping:
+          chainId: chainId
+          contractAddress: contractAddress
+          eventId: eventId
+          id: packNftContractId
+        insertion_order: null
+        remote_table:
+          name: eventPassNft
+          schema: public

--- a/hasura/app/metadata/databases/default/tables/tables.yaml
+++ b/hasura/app/metadata/databases/default/tables/tables.yaml
@@ -15,6 +15,7 @@
 - "!include public_kycStatus.yaml"
 - "!include public_nftTransfer.yaml"
 - "!include public_orderStatus.yaml"
+- "!include public_packNftContract.yaml"
 - "!include public_roleAssignments.yaml"
 - "!include public_roles.yaml"
 - "!include public_stripeCheckoutSession.yaml"

--- a/hasura/app/migrations/default/1702546195591_create_pack_nft_contract_ticket_pk_02/down.sql
+++ b/hasura/app/migrations/default/1702546195591_create_pack_nft_contract_ticket_pk_02/down.sql
@@ -1,0 +1,18 @@
+
+alter table "public"."eventPassNft" drop constraint "eventPassNft_packNftContractId_fkey";
+
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "public"."eventPassNft" add column "packNftContractId" uuid
+--  null;
+
+DROP TABLE "public"."packNftContract";
+
+alter table "public"."eventPassNftContract" drop constraint "eventPassNftContract_chainId_contractAddress_key";
+alter table "public"."eventPassNftContract" add constraint "eventPassNftContract_chainId_contractAddress_key" unique ("chainId", "contractAddress");
+
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- drop schema "packNftContract" cascade;
+
+drop schema "packNftContract" cascade;

--- a/hasura/app/migrations/default/1702546195591_create_pack_nft_contract_ticket_pk_02/down.sql
+++ b/hasura/app/migrations/default/1702546195591_create_pack_nft_contract_ticket_pk_02/down.sql
@@ -1,18 +1,11 @@
-
+-- Drop the foreign key constraint
 alter table "public"."eventPassNft" drop constraint "eventPassNft_packNftContractId_fkey";
 
--- Could not auto-generate a down migration.
--- Please write an appropriate down migration for the SQL below:
--- alter table "public"."eventPassNft" add column "packNftContractId" uuid
---  null;
+-- Drop the packNftContractId column
+alter table "public"."eventPassNft" drop column "packNftContractId";
 
+-- Drop the packNftContract table
 DROP TABLE "public"."packNftContract";
 
-alter table "public"."eventPassNftContract" drop constraint "eventPassNftContract_chainId_contractAddress_key";
-alter table "public"."eventPassNftContract" add constraint "eventPassNftContract_chainId_contractAddress_key" unique ("chainId", "contractAddress");
-
--- Could not auto-generate a down migration.
--- Please write an appropriate down migration for the SQL below:
--- drop schema "packNftContract" cascade;
-
-drop schema "packNftContract" cascade;
+-- Drop the pgcrypto extension
+DROP EXTENSION IF EXISTS pgcrypto;

--- a/hasura/app/migrations/default/1702546195591_create_pack_nft_contract_ticket_pk_02/up.sql
+++ b/hasura/app/migrations/default/1702546195591_create_pack_nft_contract_ticket_pk_02/up.sql
@@ -1,0 +1,35 @@
+
+create schema "packNftContract";
+
+drop schema "packNftContract" cascade;
+
+alter table "public"."eventPassNftContract" drop constraint "eventPassNftContract_contractAddress_chainId_key";
+alter table "public"."eventPassNftContract" add constraint "eventPassNftContract_chainId_contractAddress_key" unique ("chainId", "contractAddress");
+
+CREATE TABLE "public"."packNftContract" ("id" uuid NOT NULL DEFAULT gen_random_uuid(), "chainId" text NOT NULL, "contractAddress" text NOT NULL, "rewardsPerPack" integer NOT NULL DEFAULT 1, "created_at" timestamptz NOT NULL DEFAULT now(), "updated_at" timestamptz NOT NULL DEFAULT now(), "organizerId" text NOT NULL, "eventId" text NOT NULL, "packId" text NOT NULL, "eventPassIds" jsonb NOT NULL, PRIMARY KEY ("id") , UNIQUE ("id"), UNIQUE ("contractAddress", "chainId"));COMMENT ON TABLE "public"."packNftContract" IS E'packNftContract model to manage the NFTs associated with each pack.';
+CREATE OR REPLACE FUNCTION "public"."set_current_timestamp_updated_at"()
+RETURNS TRIGGER AS $$
+DECLARE
+  _new record;
+BEGIN
+  _new := NEW;
+  _new."updated_at" = NOW();
+  RETURN _new;
+END;
+$$ LANGUAGE plpgsql;
+CREATE TRIGGER "set_public_packNftContract_updated_at"
+BEFORE UPDATE ON "public"."packNftContract"
+FOR EACH ROW
+EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
+COMMENT ON TRIGGER "set_public_packNftContract_updated_at" ON "public"."packNftContract"
+IS 'trigger to set value of column "updated_at" to current timestamp on row update';
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+alter table "public"."eventPassNft" add column "packNftContractId" uuid
+ null;
+
+alter table "public"."eventPassNft"
+  add constraint "eventPassNft_packNftContractId_fkey"
+  foreign key ("packNftContractId")
+  references "public"."packNftContract"
+  ("id") on update restrict on delete restrict;

--- a/hasura/app/migrations/default/1702546195591_create_pack_nft_contract_ticket_pk_02/up.sql
+++ b/hasura/app/migrations/default/1702546195591_create_pack_nft_contract_ticket_pk_02/up.sql
@@ -1,11 +1,3 @@
-
-create schema "packNftContract";
-
-drop schema "packNftContract" cascade;
-
-alter table "public"."eventPassNftContract" drop constraint "eventPassNftContract_contractAddress_chainId_key";
-alter table "public"."eventPassNftContract" add constraint "eventPassNftContract_chainId_contractAddress_key" unique ("chainId", "contractAddress");
-
 CREATE TABLE "public"."packNftContract" ("id" uuid NOT NULL DEFAULT gen_random_uuid(), "chainId" text NOT NULL, "contractAddress" text NOT NULL, "rewardsPerPack" integer NOT NULL DEFAULT 1, "created_at" timestamptz NOT NULL DEFAULT now(), "updated_at" timestamptz NOT NULL DEFAULT now(), "organizerId" text NOT NULL, "eventId" text NOT NULL, "packId" text NOT NULL, "eventPassIds" jsonb NOT NULL, PRIMARY KEY ("id") , UNIQUE ("id"), UNIQUE ("contractAddress", "chainId"));COMMENT ON TABLE "public"."packNftContract" IS E'packNftContract model to manage the NFTs associated with each pack.';
 CREATE OR REPLACE FUNCTION "public"."set_current_timestamp_updated_at"()
 RETURNS TRIGGER AS $$

--- a/libs/gql/admin/api/src/generated/schema.graphql
+++ b/libs/gql/admin/api/src/generated/schema.graphql
@@ -9909,6 +9909,7 @@ type eventPassNft {
 
   """Ties the event pass NFT to a specific organizer within the platform"""
   organizerId: String!
+  packNftContractId: uuid
 
   """
   The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms.
@@ -10302,7 +10303,7 @@ enum eventPassNftContract_constraint {
   """
   unique or primary key constraint on columns "chainId", "contractAddress"
   """
-  eventPassNftContract_contractAddress_chainId_key
+  eventPassNftContract_chainId_contractAddress_key
 }
 
 """
@@ -10800,6 +10801,7 @@ input eventPassNft_bool_exp {
   nftTransfers: nftTransfer_bool_exp
   nftTransfers_aggregate: nftTransfer_aggregate_bool_exp
   organizerId: String_comparison_exp
+  packNftContractId: uuid_comparison_exp
   tokenId: bigint_comparison_exp
   tokenUri: String_comparison_exp
   updated_at: timestamptz_comparison_exp
@@ -10917,6 +10919,7 @@ input eventPassNft_insert_input {
 
   """Ties the event pass NFT to a specific organizer within the platform"""
   organizerId: String
+  packNftContractId: uuid
 
   """
   The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms.
@@ -10965,6 +10968,7 @@ type eventPassNft_max_fields {
 
   """Ties the event pass NFT to a specific organizer within the platform"""
   organizerId: String
+  packNftContractId: uuid
 
   """
   The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms.
@@ -11015,6 +11019,7 @@ input eventPassNft_max_order_by {
 
   """Ties the event pass NFT to a specific organizer within the platform"""
   organizerId: order_by
+  packNftContractId: order_by
 
   """
   The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms.
@@ -11063,6 +11068,7 @@ type eventPassNft_min_fields {
 
   """Ties the event pass NFT to a specific organizer within the platform"""
   organizerId: String
+  packNftContractId: uuid
 
   """
   The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms.
@@ -11113,6 +11119,7 @@ input eventPassNft_min_order_by {
 
   """Ties the event pass NFT to a specific organizer within the platform"""
   organizerId: order_by
+  packNftContractId: order_by
 
   """
   The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms.
@@ -11165,6 +11172,7 @@ input eventPassNft_order_by {
   metadata: order_by
   nftTransfers_aggregate: nftTransfer_aggregate_order_by
   organizerId: order_by
+  packNftContractId: order_by
   tokenId: order_by
   tokenUri: order_by
   updated_at: order_by
@@ -11222,6 +11230,9 @@ enum eventPassNft_select_column {
 
   """column name"""
   organizerId
+
+  """column name"""
+  packNftContractId
 
   """column name"""
   tokenId
@@ -11296,6 +11307,7 @@ input eventPassNft_set_input {
 
   """Ties the event pass NFT to a specific organizer within the platform"""
   organizerId: String
+  packNftContractId: uuid
 
   """
   The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms.
@@ -11419,6 +11431,7 @@ input eventPassNft_stream_cursor_value_input {
 
   """Ties the event pass NFT to a specific organizer within the platform"""
   organizerId: String
+  packNftContractId: uuid
 
   """
   The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms.
@@ -11489,6 +11502,9 @@ enum eventPassNft_update_column {
 
   """column name"""
   organizerId
+
+  """column name"""
+  packNftContractId
 
   """column name"""
   tokenId
@@ -14160,6 +14176,19 @@ type mutation_root {
   delete_orderStatus_by_pk(value: String!): orderStatus
 
   """
+  delete data from the table: "packNftContract"
+  """
+  delete_packNftContract(
+    """filter the rows which have to be deleted"""
+    where: packNftContract_bool_exp!
+  ): packNftContract_mutation_response
+
+  """
+  delete single row from the table: "packNftContract"
+  """
+  delete_packNftContract_by_pk(id: uuid!): packNftContract
+
+  """
   delete data from the table: "roleAssignments"
   """
   delete_roleAssignments(
@@ -14617,6 +14646,28 @@ type mutation_root {
     """upsert condition"""
     on_conflict: orderStatus_on_conflict
   ): orderStatus
+
+  """
+  insert data into the table: "packNftContract"
+  """
+  insert_packNftContract(
+    """the rows to be inserted"""
+    objects: [packNftContract_insert_input!]!
+
+    """upsert condition"""
+    on_conflict: packNftContract_on_conflict
+  ): packNftContract_mutation_response
+
+  """
+  insert a single row into the table: "packNftContract"
+  """
+  insert_packNftContract_one(
+    """the row to be inserted"""
+    object: packNftContract_insert_input!
+
+    """upsert condition"""
+    on_conflict: packNftContract_on_conflict
+  ): packNftContract
 
   """
   insert data into the table: "roleAssignments"
@@ -16382,6 +16433,82 @@ type mutation_root {
   ): [orderStatus_mutation_response]
 
   """
+  update data of the table: "packNftContract"
+  """
+  update_packNftContract(
+    """append existing jsonb value of filtered columns with new jsonb value"""
+    _append: packNftContract_append_input
+
+    """
+    delete the field or element with specified path (for JSON arrays, negative integers count from the end)
+    """
+    _delete_at_path: packNftContract_delete_at_path_input
+
+    """
+    delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array
+    """
+    _delete_elem: packNftContract_delete_elem_input
+
+    """
+    delete key/value pair or string element. key/value pairs are matched based on their key value
+    """
+    _delete_key: packNftContract_delete_key_input
+
+    """increments the numeric columns with given value of the filtered values"""
+    _inc: packNftContract_inc_input
+
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
+    _prepend: packNftContract_prepend_input
+
+    """sets the columns of the filtered rows to the given values"""
+    _set: packNftContract_set_input
+
+    """filter the rows which have to be updated"""
+    where: packNftContract_bool_exp!
+  ): packNftContract_mutation_response
+
+  """
+  update single row of the table: "packNftContract"
+  """
+  update_packNftContract_by_pk(
+    """append existing jsonb value of filtered columns with new jsonb value"""
+    _append: packNftContract_append_input
+
+    """
+    delete the field or element with specified path (for JSON arrays, negative integers count from the end)
+    """
+    _delete_at_path: packNftContract_delete_at_path_input
+
+    """
+    delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array
+    """
+    _delete_elem: packNftContract_delete_elem_input
+
+    """
+    delete key/value pair or string element. key/value pairs are matched based on their key value
+    """
+    _delete_key: packNftContract_delete_key_input
+
+    """increments the numeric columns with given value of the filtered values"""
+    _inc: packNftContract_inc_input
+
+    """prepend existing jsonb value of filtered columns with new jsonb value"""
+    _prepend: packNftContract_prepend_input
+
+    """sets the columns of the filtered rows to the given values"""
+    _set: packNftContract_set_input
+    pk_columns: packNftContract_pk_columns_input!
+  ): packNftContract
+
+  """
+  update multiples rows of table: "packNftContract"
+  """
+  update_packNftContract_many(
+    """updates to execute, in order"""
+    updates: [packNftContract_updates!]!
+  ): [packNftContract_mutation_response]
+
+  """
   update data of the table: "roleAssignments"
   """
   update_roleAssignments(
@@ -17696,6 +17823,424 @@ enum order_by {
   desc_nulls_last
 }
 
+"""packNftContract model to manage the NFTs associated with each pack."""
+type packNftContract {
+  chainId: String!
+  contractAddress: String!
+  created_at: timestamptz!
+  eventId: String!
+  eventPassIds(
+    """JSON select path"""
+    path: String
+  ): jsonb!
+
+  """An array relationship"""
+  eventPassNfts(
+    """distinct select on columns"""
+    distinct_on: [eventPassNft_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [eventPassNft_order_by!]
+
+    """filter the rows returned"""
+    where: eventPassNft_bool_exp
+  ): [eventPassNft!]!
+
+  """An aggregate relationship"""
+  eventPassNfts_aggregate(
+    """distinct select on columns"""
+    distinct_on: [eventPassNft_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [eventPassNft_order_by!]
+
+    """filter the rows returned"""
+    where: eventPassNft_bool_exp
+  ): eventPassNft_aggregate!
+  id: uuid!
+  organizerId: String!
+  packId: String!
+  rewardsPerPack: Int!
+  updated_at: timestamptz!
+}
+
+"""
+aggregated selection of "packNftContract"
+"""
+type packNftContract_aggregate {
+  aggregate: packNftContract_aggregate_fields
+  nodes: [packNftContract!]!
+}
+
+"""
+aggregate fields of "packNftContract"
+"""
+type packNftContract_aggregate_fields {
+  avg: packNftContract_avg_fields
+  count(columns: [packNftContract_select_column!], distinct: Boolean): Int!
+  max: packNftContract_max_fields
+  min: packNftContract_min_fields
+  stddev: packNftContract_stddev_fields
+  stddev_pop: packNftContract_stddev_pop_fields
+  stddev_samp: packNftContract_stddev_samp_fields
+  sum: packNftContract_sum_fields
+  var_pop: packNftContract_var_pop_fields
+  var_samp: packNftContract_var_samp_fields
+  variance: packNftContract_variance_fields
+}
+
+"""append existing jsonb value of filtered columns with new jsonb value"""
+input packNftContract_append_input {
+  eventPassIds: jsonb
+}
+
+"""aggregate avg on columns"""
+type packNftContract_avg_fields {
+  rewardsPerPack: Float
+}
+
+"""
+Boolean expression to filter rows from the table "packNftContract". All fields are combined with a logical 'AND'.
+"""
+input packNftContract_bool_exp {
+  _and: [packNftContract_bool_exp!]
+  _not: packNftContract_bool_exp
+  _or: [packNftContract_bool_exp!]
+  chainId: String_comparison_exp
+  contractAddress: String_comparison_exp
+  created_at: timestamptz_comparison_exp
+  eventId: String_comparison_exp
+  eventPassIds: jsonb_comparison_exp
+  eventPassNfts: eventPassNft_bool_exp
+  eventPassNfts_aggregate: eventPassNft_aggregate_bool_exp
+  id: uuid_comparison_exp
+  organizerId: String_comparison_exp
+  packId: String_comparison_exp
+  rewardsPerPack: Int_comparison_exp
+  updated_at: timestamptz_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "packNftContract"
+"""
+enum packNftContract_constraint {
+  """
+  unique or primary key constraint on columns "chainId", "contractAddress"
+  """
+  packNftContract_contractAddress_chainId_key
+
+  """
+  unique or primary key constraint on columns "id"
+  """
+  packNftContract_pkey
+}
+
+"""
+delete the field or element with specified path (for JSON arrays, negative integers count from the end)
+"""
+input packNftContract_delete_at_path_input {
+  eventPassIds: [String!]
+}
+
+"""
+delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array
+"""
+input packNftContract_delete_elem_input {
+  eventPassIds: Int
+}
+
+"""
+delete key/value pair or string element. key/value pairs are matched based on their key value
+"""
+input packNftContract_delete_key_input {
+  eventPassIds: String
+}
+
+"""
+input type for incrementing numeric columns in table "packNftContract"
+"""
+input packNftContract_inc_input {
+  rewardsPerPack: Int
+}
+
+"""
+input type for inserting data into table "packNftContract"
+"""
+input packNftContract_insert_input {
+  chainId: String
+  contractAddress: String
+  created_at: timestamptz
+  eventId: String
+  eventPassIds: jsonb
+  eventPassNfts: eventPassNft_arr_rel_insert_input
+  id: uuid
+  organizerId: String
+  packId: String
+  rewardsPerPack: Int
+  updated_at: timestamptz
+}
+
+"""aggregate max on columns"""
+type packNftContract_max_fields {
+  chainId: String
+  contractAddress: String
+  created_at: timestamptz
+  eventId: String
+  id: uuid
+  organizerId: String
+  packId: String
+  rewardsPerPack: Int
+  updated_at: timestamptz
+}
+
+"""aggregate min on columns"""
+type packNftContract_min_fields {
+  chainId: String
+  contractAddress: String
+  created_at: timestamptz
+  eventId: String
+  id: uuid
+  organizerId: String
+  packId: String
+  rewardsPerPack: Int
+  updated_at: timestamptz
+}
+
+"""
+response of any mutation on the table "packNftContract"
+"""
+type packNftContract_mutation_response {
+  """number of rows affected by the mutation"""
+  affected_rows: Int!
+
+  """data from the rows affected by the mutation"""
+  returning: [packNftContract!]!
+}
+
+"""
+on_conflict condition type for table "packNftContract"
+"""
+input packNftContract_on_conflict {
+  constraint: packNftContract_constraint!
+  update_columns: [packNftContract_update_column!]! = []
+  where: packNftContract_bool_exp
+}
+
+"""Ordering options when selecting data from "packNftContract"."""
+input packNftContract_order_by {
+  chainId: order_by
+  contractAddress: order_by
+  created_at: order_by
+  eventId: order_by
+  eventPassIds: order_by
+  eventPassNfts_aggregate: eventPassNft_aggregate_order_by
+  id: order_by
+  organizerId: order_by
+  packId: order_by
+  rewardsPerPack: order_by
+  updated_at: order_by
+}
+
+"""primary key columns input for table: packNftContract"""
+input packNftContract_pk_columns_input {
+  id: uuid!
+}
+
+"""prepend existing jsonb value of filtered columns with new jsonb value"""
+input packNftContract_prepend_input {
+  eventPassIds: jsonb
+}
+
+"""
+select columns of table "packNftContract"
+"""
+enum packNftContract_select_column {
+  """column name"""
+  chainId
+
+  """column name"""
+  contractAddress
+
+  """column name"""
+  created_at
+
+  """column name"""
+  eventId
+
+  """column name"""
+  eventPassIds
+
+  """column name"""
+  id
+
+  """column name"""
+  organizerId
+
+  """column name"""
+  packId
+
+  """column name"""
+  rewardsPerPack
+
+  """column name"""
+  updated_at
+}
+
+"""
+input type for updating data in table "packNftContract"
+"""
+input packNftContract_set_input {
+  chainId: String
+  contractAddress: String
+  created_at: timestamptz
+  eventId: String
+  eventPassIds: jsonb
+  id: uuid
+  organizerId: String
+  packId: String
+  rewardsPerPack: Int
+  updated_at: timestamptz
+}
+
+"""aggregate stddev on columns"""
+type packNftContract_stddev_fields {
+  rewardsPerPack: Float
+}
+
+"""aggregate stddev_pop on columns"""
+type packNftContract_stddev_pop_fields {
+  rewardsPerPack: Float
+}
+
+"""aggregate stddev_samp on columns"""
+type packNftContract_stddev_samp_fields {
+  rewardsPerPack: Float
+}
+
+"""
+Streaming cursor of the table "packNftContract"
+"""
+input packNftContract_stream_cursor_input {
+  """Stream column input with initial value"""
+  initial_value: packNftContract_stream_cursor_value_input!
+
+  """cursor ordering"""
+  ordering: cursor_ordering
+}
+
+"""Initial value of the column from where the streaming should start"""
+input packNftContract_stream_cursor_value_input {
+  chainId: String
+  contractAddress: String
+  created_at: timestamptz
+  eventId: String
+  eventPassIds: jsonb
+  id: uuid
+  organizerId: String
+  packId: String
+  rewardsPerPack: Int
+  updated_at: timestamptz
+}
+
+"""aggregate sum on columns"""
+type packNftContract_sum_fields {
+  rewardsPerPack: Int
+}
+
+"""
+update columns of table "packNftContract"
+"""
+enum packNftContract_update_column {
+  """column name"""
+  chainId
+
+  """column name"""
+  contractAddress
+
+  """column name"""
+  created_at
+
+  """column name"""
+  eventId
+
+  """column name"""
+  eventPassIds
+
+  """column name"""
+  id
+
+  """column name"""
+  organizerId
+
+  """column name"""
+  packId
+
+  """column name"""
+  rewardsPerPack
+
+  """column name"""
+  updated_at
+}
+
+input packNftContract_updates {
+  """append existing jsonb value of filtered columns with new jsonb value"""
+  _append: packNftContract_append_input
+
+  """
+  delete the field or element with specified path (for JSON arrays, negative integers count from the end)
+  """
+  _delete_at_path: packNftContract_delete_at_path_input
+
+  """
+  delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array
+  """
+  _delete_elem: packNftContract_delete_elem_input
+
+  """
+  delete key/value pair or string element. key/value pairs are matched based on their key value
+  """
+  _delete_key: packNftContract_delete_key_input
+
+  """increments the numeric columns with given value of the filtered values"""
+  _inc: packNftContract_inc_input
+
+  """prepend existing jsonb value of filtered columns with new jsonb value"""
+  _prepend: packNftContract_prepend_input
+
+  """sets the columns of the filtered rows to the given values"""
+  _set: packNftContract_set_input
+
+  """filter the rows which have to be updated"""
+  where: packNftContract_bool_exp!
+}
+
+"""aggregate var_pop on columns"""
+type packNftContract_var_pop_fields {
+  rewardsPerPack: Float
+}
+
+"""aggregate var_samp on columns"""
+type packNftContract_var_samp_fields {
+  rewardsPerPack: Float
+}
+
+"""aggregate variance on columns"""
+type packNftContract_variance_fields {
+  rewardsPerPack: Float
+}
+
 type query_root {
   """
   fetch data from the table: "account"
@@ -18794,6 +19339,49 @@ type query_root {
     stage: Stage! = PUBLISHED
     where: OrganizerWhereInput
   ): OrganizerConnection!
+
+  """
+  fetch data from the table: "packNftContract"
+  """
+  packNftContract(
+    """distinct select on columns"""
+    distinct_on: [packNftContract_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [packNftContract_order_by!]
+
+    """filter the rows returned"""
+    where: packNftContract_bool_exp
+  ): [packNftContract!]!
+
+  """
+  fetch aggregated fields from the table: "packNftContract"
+  """
+  packNftContract_aggregate(
+    """distinct select on columns"""
+    distinct_on: [packNftContract_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [packNftContract_order_by!]
+
+    """filter the rows returned"""
+    where: packNftContract_bool_exp
+  ): packNftContract_aggregate!
+
+  """fetch data from the table: "packNftContract" using primary key columns"""
+  packNftContract_by_pk(id: uuid!): packNftContract
 
   """
   fetch data from the table: "roleAssignments"
@@ -21347,6 +21935,63 @@ type subscription_root {
     """filter the rows returned"""
     where: orderStatus_bool_exp
   ): [orderStatus!]!
+
+  """
+  fetch data from the table: "packNftContract"
+  """
+  packNftContract(
+    """distinct select on columns"""
+    distinct_on: [packNftContract_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [packNftContract_order_by!]
+
+    """filter the rows returned"""
+    where: packNftContract_bool_exp
+  ): [packNftContract!]!
+
+  """
+  fetch aggregated fields from the table: "packNftContract"
+  """
+  packNftContract_aggregate(
+    """distinct select on columns"""
+    distinct_on: [packNftContract_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [packNftContract_order_by!]
+
+    """filter the rows returned"""
+    where: packNftContract_bool_exp
+  ): packNftContract_aggregate!
+
+  """fetch data from the table: "packNftContract" using primary key columns"""
+  packNftContract_by_pk(id: uuid!): packNftContract
+
+  """
+  fetch data from the table in a streaming manner: "packNftContract"
+  """
+  packNftContract_stream(
+    """maximum number of rows returned in a single batch"""
+    batch_size: Int!
+
+    """cursor to stream the results returned by the query"""
+    cursor: [packNftContract_stream_cursor_input]!
+
+    """filter the rows returned"""
+    where: packNftContract_bool_exp
+  ): [packNftContract!]!
 
   """
   fetch data from the table: "roleAssignments"

--- a/libs/gql/admin/api/src/generated/schema.graphql
+++ b/libs/gql/admin/api/src/generated/schema.graphql
@@ -9909,6 +9909,9 @@ type eventPassNft {
 
   """Ties the event pass NFT to a specific organizer within the platform"""
   organizerId: String!
+
+  """An object relationship"""
+  packNftContract: packNftContract
   packNftContractId: uuid
 
   """
@@ -10303,7 +10306,7 @@ enum eventPassNftContract_constraint {
   """
   unique or primary key constraint on columns "chainId", "contractAddress"
   """
-  eventPassNftContract_chainId_contractAddress_key
+  eventPassNftContract_contractAddress_chainId_key
 }
 
 """
@@ -10801,6 +10804,7 @@ input eventPassNft_bool_exp {
   nftTransfers: nftTransfer_bool_exp
   nftTransfers_aggregate: nftTransfer_aggregate_bool_exp
   organizerId: String_comparison_exp
+  packNftContract: packNftContract_bool_exp
   packNftContractId: uuid_comparison_exp
   tokenId: bigint_comparison_exp
   tokenUri: String_comparison_exp
@@ -10919,6 +10923,7 @@ input eventPassNft_insert_input {
 
   """Ties the event pass NFT to a specific organizer within the platform"""
   organizerId: String
+  packNftContract: packNftContract_obj_rel_insert_input
   packNftContractId: uuid
 
   """
@@ -11172,6 +11177,7 @@ input eventPassNft_order_by {
   metadata: order_by
   nftTransfers_aggregate: nftTransfer_aggregate_order_by
   organizerId: order_by
+  packNftContract: packNftContract_order_by
   packNftContractId: order_by
   tokenId: order_by
   tokenUri: order_by
@@ -18027,6 +18033,16 @@ type packNftContract_mutation_response {
 
   """data from the rows affected by the mutation"""
   returning: [packNftContract!]!
+}
+
+"""
+input type for inserting object relation for remote table "packNftContract"
+"""
+input packNftContract_obj_rel_insert_input {
+  data: packNftContract_insert_input!
+
+  """upsert condition"""
+  on_conflict: packNftContract_on_conflict
 }
 
 """

--- a/libs/gql/admin/api/src/generated/schema.json
+++ b/libs/gql/admin/api/src/generated/schema.json
@@ -49327,6 +49327,18 @@
             "deprecationReason": null
           },
           {
+            "name": "packNftContract",
+            "description": "An object relationship",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "packNftContractId",
             "description": null,
             "args": [],
@@ -51568,7 +51580,7 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "eventPassNftContract_chainId_contractAddress_key",
+            "name": "eventPassNftContract_contractAddress_chainId_key",
             "description": "unique or primary key constraint on columns \"chainId\", \"contractAddress\"",
             "isDeprecated": false,
             "deprecationReason": null
@@ -54224,6 +54236,18 @@
             "deprecationReason": null
           },
           {
+            "name": "packNftContract",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftContract_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "packNftContractId",
             "description": null,
             "type": {
@@ -54609,6 +54633,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContract",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftContract_obj_rel_insert_input",
               "ofType": null
             },
             "defaultValue": null,
@@ -55702,6 +55738,18 @@
             "type": {
               "kind": "ENUM",
               "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContract",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftContract_order_by",
               "ofType": null
             },
             "defaultValue": null,
@@ -87710,6 +87758,45 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_obj_rel_insert_input",
+        "description": "input type for inserting object relation for remote table \"packNftContract\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "data",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "packNftContract_insert_input",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_conflict",
+            "description": "upsert condition",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftContract_on_conflict",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/libs/gql/admin/api/src/generated/schema.json
+++ b/libs/gql/admin/api/src/generated/schema.json
@@ -49327,6 +49327,18 @@
             "deprecationReason": null
           },
           {
+            "name": "packNftContractId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "tokenId",
             "description": "The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms.",
             "args": [],
@@ -51556,7 +51568,7 @@
         "interfaces": null,
         "enumValues": [
           {
-            "name": "eventPassNftContract_contractAddress_chainId_key",
+            "name": "eventPassNftContract_chainId_contractAddress_key",
             "description": "unique or primary key constraint on columns \"chainId\", \"contractAddress\"",
             "isDeprecated": false,
             "deprecationReason": null
@@ -54212,6 +54224,18 @@
             "deprecationReason": null
           },
           {
+            "name": "packNftContractId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "uuid_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "tokenId",
             "description": null,
             "type": {
@@ -54592,6 +54616,18 @@
             "deprecationReason": null
           },
           {
+            "name": "packNftContractId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "tokenId",
             "description": "The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms.",
             "type": {
@@ -54758,6 +54794,18 @@
             "deprecationReason": null
           },
           {
+            "name": "packNftContractId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "tokenId",
             "description": "The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms.",
             "args": [],
@@ -54916,6 +54964,18 @@
           {
             "name": "organizerId",
             "description": "Ties the event pass NFT to a specific organizer within the platform",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContractId",
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
@@ -55092,6 +55152,18 @@
             "deprecationReason": null
           },
           {
+            "name": "packNftContractId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "tokenId",
             "description": "The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms.",
             "args": [],
@@ -55250,6 +55322,18 @@
           {
             "name": "organizerId",
             "description": "Ties the event pass NFT to a specific organizer within the platform",
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContractId",
+            "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
@@ -55625,6 +55709,18 @@
             "deprecationReason": null
           },
           {
+            "name": "packNftContractId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "tokenId",
             "description": null,
             "type": {
@@ -55791,6 +55887,12 @@
           },
           {
             "name": "organizerId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContractId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -55994,6 +56096,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContractId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
               "ofType": null
             },
             "defaultValue": null,
@@ -56369,6 +56483,18 @@
             "deprecationReason": null
           },
           {
+            "name": "packNftContractId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "tokenId",
             "description": "The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms.",
             "type": {
@@ -56531,6 +56657,12 @@
           },
           {
             "name": "organizerId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContractId",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -70171,6 +70303,64 @@
             "deprecationReason": null
           },
           {
+            "name": "delete_packNftContract",
+            "description": "delete data from the table: \"packNftContract\"",
+            "args": [
+              {
+                "name": "where",
+                "description": "filter the rows which have to be deleted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "packNftContract_bool_exp",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "delete_packNftContract_by_pk",
+            "description": "delete single row from the table: \"packNftContract\"",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "uuid",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "delete_roleAssignments",
             "description": "delete data from the table: \"roleAssignments\"",
             "args": [
@@ -72014,6 +72204,96 @@
             "type": {
               "kind": "OBJECT",
               "name": "orderStatus",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "insert_packNftContract",
+            "description": "insert data into the table: \"packNftContract\"",
+            "args": [
+              {
+                "name": "objects",
+                "description": "the rows to be inserted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "packNftContract_insert_input",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "on_conflict",
+                "description": "upsert condition",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_on_conflict",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "insert_packNftContract_one",
+            "description": "insert a single row into the table: \"packNftContract\"",
+            "args": [
+              {
+                "name": "object",
+                "description": "the row to be inserted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "packNftContract_insert_input",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "on_conflict",
+                "description": "upsert condition",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_on_conflict",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract",
               "ofType": null
             },
             "isDeprecated": false,
@@ -80638,6 +80918,273 @@
             "deprecationReason": null
           },
           {
+            "name": "update_packNftContract",
+            "description": "update data of the table: \"packNftContract\"",
+            "args": [
+              {
+                "name": "_append",
+                "description": "append existing jsonb value of filtered columns with new jsonb value",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_append_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_delete_at_path",
+                "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_delete_at_path_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_delete_elem",
+                "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_delete_elem_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_delete_key",
+                "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_delete_key_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_inc",
+                "description": "increments the numeric columns with given value of the filtered values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_inc_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_prepend",
+                "description": "prepend existing jsonb value of filtered columns with new jsonb value",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_prepend_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_set",
+                "description": "sets the columns of the filtered rows to the given values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_set_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows which have to be updated",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "packNftContract_bool_exp",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_packNftContract_by_pk",
+            "description": "update single row of the table: \"packNftContract\"",
+            "args": [
+              {
+                "name": "_append",
+                "description": "append existing jsonb value of filtered columns with new jsonb value",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_append_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_delete_at_path",
+                "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_delete_at_path_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_delete_elem",
+                "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_delete_elem_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_delete_key",
+                "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_delete_key_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_inc",
+                "description": "increments the numeric columns with given value of the filtered values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_inc_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_prepend",
+                "description": "prepend existing jsonb value of filtered columns with new jsonb value",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_prepend_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "_set",
+                "description": "sets the columns of the filtered rows to the given values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_set_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pk_columns",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "packNftContract_pk_columns_input",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_packNftContract_many",
+            "description": "update multiples rows of table: \"packNftContract\"",
+            "args": [
+              {
+                "name": "updates",
+                "description": "updates to execute, in order",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "packNftContract_updates",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "packNftContract_mutation_response",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "update_roleAssignments",
             "description": "update data of the table: \"roleAssignments\"",
             "args": [
@@ -85751,6 +86298,2390 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftContract",
+        "description": "packNftContract model to manage the NFTs associated with each pack.",
+        "fields": [
+          {
+            "name": "chainId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassIds",
+            "description": null,
+            "args": [
+              {
+                "name": "path",
+                "description": "JSON select path",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "jsonb",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts",
+            "description": "An array relationship",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "eventPassNft_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "eventPassNft_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "eventPassNft_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "eventPassNft",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts_aggregate",
+            "description": "An aggregate relationship",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "eventPassNft_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "eventPassNft_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "eventPassNft_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "eventPassNft_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "uuid",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftContract_aggregate",
+        "description": "aggregated selection of \"packNftContract\"",
+        "fields": [
+          {
+            "name": "aggregate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract_aggregate_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "packNftContract",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftContract_aggregate_fields",
+        "description": "aggregate fields of \"packNftContract\"",
+        "fields": [
+          {
+            "name": "avg",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract_avg_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count",
+            "description": null,
+            "args": [
+              {
+                "name": "columns",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "packNftContract_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "distinct",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "max",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract_max_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "min",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract_min_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract_stddev_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev_pop",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract_stddev_pop_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev_samp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract_stddev_samp_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sum",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract_sum_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "var_pop",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract_var_pop_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "var_samp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract_var_samp_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "variance",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract_variance_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_append_input",
+        "description": "append existing jsonb value of filtered columns with new jsonb value",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "eventPassIds",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftContract_avg_fields",
+        "description": "aggregate avg on columns",
+        "fields": [
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_bool_exp",
+        "description": "Boolean expression to filter rows from the table \"packNftContract\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftContract_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "chainId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassIds",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "jsonb_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "eventPassNft_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts_aggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "eventPassNft_aggregate_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "uuid_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "Int_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "packNftContract_constraint",
+        "description": "unique or primary key constraints on table \"packNftContract\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "packNftContract_contractAddress_chainId_key",
+            "description": "unique or primary key constraint on columns \"chainId\", \"contractAddress\"",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContract_pkey",
+            "description": "unique or primary key constraint on columns \"id\"",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_delete_at_path_input",
+        "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "eventPassIds",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_delete_elem_input",
+        "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "eventPassIds",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_delete_key_input",
+        "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "eventPassIds",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_inc_input",
+        "description": "input type for incrementing numeric columns in table \"packNftContract\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_insert_input",
+        "description": "input type for inserting data into table \"packNftContract\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "chainId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassIds",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "eventPassNft_arr_rel_insert_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftContract_max_fields",
+        "description": "aggregate max on columns",
+        "fields": [
+          {
+            "name": "chainId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftContract_min_fields",
+        "description": "aggregate min on columns",
+        "fields": [
+          {
+            "name": "chainId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftContract_mutation_response",
+        "description": "response of any mutation on the table \"packNftContract\"",
+        "fields": [
+          {
+            "name": "affected_rows",
+            "description": "number of rows affected by the mutation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "returning",
+            "description": "data from the rows affected by the mutation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "packNftContract",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_on_conflict",
+        "description": "on_conflict condition type for table \"packNftContract\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "constraint",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "packNftContract_constraint",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_columns",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "packNftContract_update_column",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": "[]",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftContract_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_order_by",
+        "description": "Ordering options when selecting data from \"packNftContract\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "chainId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassIds",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts_aggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "eventPassNft_aggregate_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_pk_columns_input",
+        "description": "primary key columns input for table: packNftContract",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "uuid",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_prepend_input",
+        "description": "prepend existing jsonb value of filtered columns with new jsonb value",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "eventPassIds",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "packNftContract_select_column",
+        "description": "select columns of table \"packNftContract\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "chainId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassIds",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rewardsPerPack",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_set_input",
+        "description": "input type for updating data in table \"packNftContract\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "chainId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassIds",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftContract_stddev_fields",
+        "description": "aggregate stddev on columns",
+        "fields": [
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftContract_stddev_pop_fields",
+        "description": "aggregate stddev_pop on columns",
+        "fields": [
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftContract_stddev_samp_fields",
+        "description": "aggregate stddev_samp on columns",
+        "fields": [
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_stream_cursor_input",
+        "description": "Streaming cursor of the table \"packNftContract\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "initial_value",
+            "description": "Stream column input with initial value",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "packNftContract_stream_cursor_value_input",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ordering",
+            "description": "cursor ordering",
+            "type": {
+              "kind": "ENUM",
+              "name": "cursor_ordering",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_stream_cursor_value_input",
+        "description": "Initial value of the column from where the streaming should start",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "chainId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassIds",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "jsonb",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftContract_sum_fields",
+        "description": "aggregate sum on columns",
+        "fields": [
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "packNftContract_update_column",
+        "description": "update columns of table \"packNftContract\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "chainId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassIds",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "rewardsPerPack",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftContract_updates",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_append",
+            "description": "append existing jsonb value of filtered columns with new jsonb value",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftContract_append_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_delete_at_path",
+            "description": "delete the field or element with specified path (for JSON arrays, negative integers count from the end)",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftContract_delete_at_path_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_delete_elem",
+            "description": "delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftContract_delete_elem_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_delete_key",
+            "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftContract_delete_key_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_inc",
+            "description": "increments the numeric columns with given value of the filtered values",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftContract_inc_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_prepend",
+            "description": "prepend existing jsonb value of filtered columns with new jsonb value",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftContract_prepend_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_set",
+            "description": "sets the columns of the filtered rows to the given values",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftContract_set_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": "filter the rows which have to be updated",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "packNftContract_bool_exp",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftContract_var_pop_fields",
+        "description": "aggregate var_pop on columns",
+        "fields": [
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftContract_var_samp_fields",
+        "description": "aggregate var_samp on columns",
+        "fields": [
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftContract_variance_fields",
+        "description": "aggregate variance on columns",
+        "fields": [
+          {
+            "name": "rewardsPerPack",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -91586,6 +94517,229 @@
                 "name": "OrganizerConnection",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContract",
+            "description": "fetch data from the table: \"packNftContract\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "packNftContract_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "packNftContract_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "packNftContract",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContract_aggregate",
+            "description": "fetch aggregated fields from the table: \"packNftContract\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "packNftContract_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "packNftContract_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "packNftContract_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContract_by_pk",
+            "description": "fetch data from the table: \"packNftContract\" using primary key columns",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "uuid",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -104354,6 +107508,302 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "orderStatus",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContract",
+            "description": "fetch data from the table: \"packNftContract\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "packNftContract_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "packNftContract_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "packNftContract",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContract_aggregate",
+            "description": "fetch aggregated fields from the table: \"packNftContract\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "packNftContract_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "packNftContract_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "packNftContract_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContract_by_pk",
+            "description": "fetch data from the table: \"packNftContract\" using primary key columns",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "uuid",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftContract",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftContract_stream",
+            "description": "fetch data from the table in a streaming manner: \"packNftContract\"",
+            "args": [
+              {
+                "name": "batch_size",
+                "description": "maximum number of rows returned in a single batch",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "cursor",
+                "description": "cursor to stream the results returned by the query",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "packNftContract_stream_cursor_input",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftContract_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "packNftContract",
                     "ofType": null
                   }
                 }

--- a/libs/gql/shared/types/src/generated/index.ts
+++ b/libs/gql/shared/types/src/generated/index.ts
@@ -7063,6 +7063,7 @@ export type EventPassNft = {
   organizer?: Maybe<Organizer>;
   /** Ties the event pass NFT to a specific organizer within the platform */
   organizerId: Scalars['String'];
+  packNftContractId?: Maybe<Scalars['uuid']>;
   /** The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms. */
   tokenId: Scalars['bigint'];
   /** The designated URI for the event pass NFT's metadata blob, providing a stable reference for data extraction. */
@@ -7436,7 +7437,7 @@ export type EventPassNftContract_Bool_Exp = {
 /** unique or primary key constraints on table "eventPassNftContract" */
 export const enum EventPassNftContract_Constraint {
   /** unique or primary key constraint on columns "chainId", "contractAddress" */
-  EventPassNftContractContractAddressChainIdKey = 'eventPassNftContract_contractAddress_chainId_key'
+  EventPassNftContractChainIdContractAddressKey = 'eventPassNftContract_chainId_contractAddress_key'
 };
 
 /** input type for inserting data into table "eventPassNftContract" */
@@ -7826,6 +7827,7 @@ export type EventPassNft_Bool_Exp = {
   nftTransfers?: InputMaybe<NftTransfer_Bool_Exp>;
   nftTransfers_aggregate?: InputMaybe<NftTransfer_Aggregate_Bool_Exp>;
   organizerId?: InputMaybe<String_Comparison_Exp>;
+  packNftContractId?: InputMaybe<Uuid_Comparison_Exp>;
   tokenId?: InputMaybe<Bigint_Comparison_Exp>;
   tokenUri?: InputMaybe<String_Comparison_Exp>;
   updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
@@ -7894,6 +7896,7 @@ export type EventPassNft_Insert_Input = {
   nftTransfers?: InputMaybe<NftTransfer_Arr_Rel_Insert_Input>;
   /** Ties the event pass NFT to a specific organizer within the platform */
   organizerId?: InputMaybe<Scalars['String']>;
+  packNftContractId?: InputMaybe<Scalars['uuid']>;
   /** The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms. */
   tokenId?: InputMaybe<Scalars['bigint']>;
   /** The designated URI for the event pass NFT's metadata blob, providing a stable reference for data extraction. */
@@ -7922,6 +7925,7 @@ export type EventPassNft_Max_Fields = {
   lastNftTransferId?: Maybe<Scalars['uuid']>;
   /** Ties the event pass NFT to a specific organizer within the platform */
   organizerId?: Maybe<Scalars['String']>;
+  packNftContractId?: Maybe<Scalars['uuid']>;
   /** The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms. */
   tokenId?: Maybe<Scalars['bigint']>;
   /** The designated URI for the event pass NFT's metadata blob, providing a stable reference for data extraction. */
@@ -7949,6 +7953,7 @@ export type EventPassNft_Max_Order_By = {
   lastNftTransferId?: InputMaybe<Order_By>;
   /** Ties the event pass NFT to a specific organizer within the platform */
   organizerId?: InputMaybe<Order_By>;
+  packNftContractId?: InputMaybe<Order_By>;
   /** The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms. */
   tokenId?: InputMaybe<Order_By>;
   /** The designated URI for the event pass NFT's metadata blob, providing a stable reference for data extraction. */
@@ -7977,6 +7982,7 @@ export type EventPassNft_Min_Fields = {
   lastNftTransferId?: Maybe<Scalars['uuid']>;
   /** Ties the event pass NFT to a specific organizer within the platform */
   organizerId?: Maybe<Scalars['String']>;
+  packNftContractId?: Maybe<Scalars['uuid']>;
   /** The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms. */
   tokenId?: Maybe<Scalars['bigint']>;
   /** The designated URI for the event pass NFT's metadata blob, providing a stable reference for data extraction. */
@@ -8004,6 +8010,7 @@ export type EventPassNft_Min_Order_By = {
   lastNftTransferId?: InputMaybe<Order_By>;
   /** Ties the event pass NFT to a specific organizer within the platform */
   organizerId?: InputMaybe<Order_By>;
+  packNftContractId?: InputMaybe<Order_By>;
   /** The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms. */
   tokenId?: InputMaybe<Order_By>;
   /** The designated URI for the event pass NFT's metadata blob, providing a stable reference for data extraction. */
@@ -8046,6 +8053,7 @@ export type EventPassNft_Order_By = {
   metadata?: InputMaybe<Order_By>;
   nftTransfers_aggregate?: InputMaybe<NftTransfer_Aggregate_Order_By>;
   organizerId?: InputMaybe<Order_By>;
+  packNftContractId?: InputMaybe<Order_By>;
   tokenId?: InputMaybe<Order_By>;
   tokenUri?: InputMaybe<Order_By>;
   updated_at?: InputMaybe<Order_By>;
@@ -8088,6 +8096,8 @@ export const enum EventPassNft_Select_Column {
   Metadata = 'metadata',
   /** column name */
   OrganizerId = 'organizerId',
+  /** column name */
+  PackNftContractId = 'packNftContractId',
   /** column name */
   TokenId = 'tokenId',
   /** column name */
@@ -8132,6 +8142,7 @@ export type EventPassNft_Set_Input = {
   metadata?: InputMaybe<Scalars['jsonb']>;
   /** Ties the event pass NFT to a specific organizer within the platform */
   organizerId?: InputMaybe<Scalars['String']>;
+  packNftContractId?: InputMaybe<Scalars['uuid']>;
   /** The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms. */
   tokenId?: InputMaybe<Scalars['bigint']>;
   /** The designated URI for the event pass NFT's metadata blob, providing a stable reference for data extraction. */
@@ -8210,6 +8221,7 @@ export type EventPassNft_Stream_Cursor_Value_Input = {
   metadata?: InputMaybe<Scalars['jsonb']>;
   /** Ties the event pass NFT to a specific organizer within the platform */
   organizerId?: InputMaybe<Scalars['String']>;
+  packNftContractId?: InputMaybe<Scalars['uuid']>;
   /** The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms. */
   tokenId?: InputMaybe<Scalars['bigint']>;
   /** The designated URI for the event pass NFT's metadata blob, providing a stable reference for data extraction. */
@@ -8256,6 +8268,8 @@ export const enum EventPassNft_Update_Column {
   Metadata = 'metadata',
   /** column name */
   OrganizerId = 'organizerId',
+  /** column name */
+  PackNftContractId = 'packNftContractId',
   /** column name */
   TokenId = 'tokenId',
   /** column name */
@@ -10312,6 +10326,10 @@ export type Mutation_Root = {
   delete_orderStatus?: Maybe<OrderStatus_Mutation_Response>;
   /** delete single row from the table: "orderStatus" */
   delete_orderStatus_by_pk?: Maybe<OrderStatus>;
+  /** delete data from the table: "packNftContract" */
+  delete_packNftContract?: Maybe<PackNftContract_Mutation_Response>;
+  /** delete single row from the table: "packNftContract" */
+  delete_packNftContract_by_pk?: Maybe<PackNftContract>;
   /** delete data from the table: "roleAssignments" */
   delete_roleAssignments?: Maybe<RoleAssignments_Mutation_Response>;
   /** delete data from the table: "roles" */
@@ -10402,6 +10420,10 @@ export type Mutation_Root = {
   insert_orderStatus?: Maybe<OrderStatus_Mutation_Response>;
   /** insert a single row into the table: "orderStatus" */
   insert_orderStatus_one?: Maybe<OrderStatus>;
+  /** insert data into the table: "packNftContract" */
+  insert_packNftContract?: Maybe<PackNftContract_Mutation_Response>;
+  /** insert a single row into the table: "packNftContract" */
+  insert_packNftContract_one?: Maybe<PackNftContract>;
   /** insert data into the table: "roleAssignments" */
   insert_roleAssignments?: Maybe<RoleAssignments_Mutation_Response>;
   /** insert a single row into the table: "roleAssignments" */
@@ -10638,6 +10660,12 @@ export type Mutation_Root = {
   update_orderStatus_by_pk?: Maybe<OrderStatus>;
   /** update multiples rows of table: "orderStatus" */
   update_orderStatus_many?: Maybe<Array<Maybe<OrderStatus_Mutation_Response>>>;
+  /** update data of the table: "packNftContract" */
+  update_packNftContract?: Maybe<PackNftContract_Mutation_Response>;
+  /** update single row of the table: "packNftContract" */
+  update_packNftContract_by_pk?: Maybe<PackNftContract>;
+  /** update multiples rows of table: "packNftContract" */
+  update_packNftContract_many?: Maybe<Array<Maybe<PackNftContract_Mutation_Response>>>;
   /** update data of the table: "roleAssignments" */
   update_roleAssignments?: Maybe<RoleAssignments_Mutation_Response>;
   /** update multiples rows of table: "roleAssignments" */
@@ -11048,6 +11076,18 @@ export type Mutation_RootDelete_OrderStatus_By_PkArgs = {
 
 
 /** mutation root */
+export type Mutation_RootDelete_PackNftContractArgs = {
+  where: PackNftContract_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_PackNftContract_By_PkArgs = {
+  id: Scalars['uuid'];
+};
+
+
+/** mutation root */
 export type Mutation_RootDelete_RoleAssignmentsArgs = {
   where: RoleAssignments_Bool_Exp;
 };
@@ -11348,6 +11388,20 @@ export type Mutation_RootInsert_OrderStatusArgs = {
 export type Mutation_RootInsert_OrderStatus_OneArgs = {
   object: OrderStatus_Insert_Input;
   on_conflict?: InputMaybe<OrderStatus_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_PackNftContractArgs = {
+  objects: Array<PackNftContract_Insert_Input>;
+  on_conflict?: InputMaybe<PackNftContract_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_PackNftContract_OneArgs = {
+  object: PackNftContract_Insert_Input;
+  on_conflict?: InputMaybe<PackNftContract_On_Conflict>;
 };
 
 
@@ -12400,6 +12454,38 @@ export type Mutation_RootUpdate_OrderStatus_ManyArgs = {
 
 
 /** mutation root */
+export type Mutation_RootUpdate_PackNftContractArgs = {
+  _append?: InputMaybe<PackNftContract_Append_Input>;
+  _delete_at_path?: InputMaybe<PackNftContract_Delete_At_Path_Input>;
+  _delete_elem?: InputMaybe<PackNftContract_Delete_Elem_Input>;
+  _delete_key?: InputMaybe<PackNftContract_Delete_Key_Input>;
+  _inc?: InputMaybe<PackNftContract_Inc_Input>;
+  _prepend?: InputMaybe<PackNftContract_Prepend_Input>;
+  _set?: InputMaybe<PackNftContract_Set_Input>;
+  where: PackNftContract_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_PackNftContract_By_PkArgs = {
+  _append?: InputMaybe<PackNftContract_Append_Input>;
+  _delete_at_path?: InputMaybe<PackNftContract_Delete_At_Path_Input>;
+  _delete_elem?: InputMaybe<PackNftContract_Delete_Elem_Input>;
+  _delete_key?: InputMaybe<PackNftContract_Delete_Key_Input>;
+  _inc?: InputMaybe<PackNftContract_Inc_Input>;
+  _prepend?: InputMaybe<PackNftContract_Prepend_Input>;
+  _set?: InputMaybe<PackNftContract_Set_Input>;
+  pk_columns: PackNftContract_Pk_Columns_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_PackNftContract_ManyArgs = {
+  updates: Array<PackNftContract_Updates>;
+};
+
+
+/** mutation root */
 export type Mutation_RootUpdate_RoleAssignmentsArgs = {
   _set?: InputMaybe<RoleAssignments_Set_Input>;
   where: RoleAssignments_Bool_Exp;
@@ -13278,6 +13364,368 @@ export const enum Order_By {
   DescNullsLast = 'desc_nulls_last'
 };
 
+/** packNftContract model to manage the NFTs associated with each pack. */
+export type PackNftContract = {
+  __typename?: 'packNftContract';
+  chainId: Scalars['String'];
+  contractAddress: Scalars['String'];
+  created_at: Scalars['timestamptz'];
+  eventId: Scalars['String'];
+  eventPassIds: Scalars['jsonb'];
+  /** An array relationship */
+  eventPassNfts: Array<EventPassNft>;
+  /** An aggregate relationship */
+  eventPassNfts_aggregate: EventPassNft_Aggregate;
+  id: Scalars['uuid'];
+  organizerId: Scalars['String'];
+  packId: Scalars['String'];
+  rewardsPerPack: Scalars['Int'];
+  updated_at: Scalars['timestamptz'];
+};
+
+
+/** packNftContract model to manage the NFTs associated with each pack. */
+export type PackNftContractEventPassIdsArgs = {
+  path?: InputMaybe<Scalars['String']>;
+};
+
+
+/** packNftContract model to manage the NFTs associated with each pack. */
+export type PackNftContractEventPassNftsArgs = {
+  distinct_on?: InputMaybe<Array<EventPassNft_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<EventPassNft_Order_By>>;
+  where?: InputMaybe<EventPassNft_Bool_Exp>;
+};
+
+
+/** packNftContract model to manage the NFTs associated with each pack. */
+export type PackNftContractEventPassNfts_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<EventPassNft_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<EventPassNft_Order_By>>;
+  where?: InputMaybe<EventPassNft_Bool_Exp>;
+};
+
+/** aggregated selection of "packNftContract" */
+export type PackNftContract_Aggregate = {
+  __typename?: 'packNftContract_aggregate';
+  aggregate?: Maybe<PackNftContract_Aggregate_Fields>;
+  nodes: Array<PackNftContract>;
+};
+
+/** aggregate fields of "packNftContract" */
+export type PackNftContract_Aggregate_Fields = {
+  __typename?: 'packNftContract_aggregate_fields';
+  avg?: Maybe<PackNftContract_Avg_Fields>;
+  count: Scalars['Int'];
+  max?: Maybe<PackNftContract_Max_Fields>;
+  min?: Maybe<PackNftContract_Min_Fields>;
+  stddev?: Maybe<PackNftContract_Stddev_Fields>;
+  stddev_pop?: Maybe<PackNftContract_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<PackNftContract_Stddev_Samp_Fields>;
+  sum?: Maybe<PackNftContract_Sum_Fields>;
+  var_pop?: Maybe<PackNftContract_Var_Pop_Fields>;
+  var_samp?: Maybe<PackNftContract_Var_Samp_Fields>;
+  variance?: Maybe<PackNftContract_Variance_Fields>;
+};
+
+
+/** aggregate fields of "packNftContract" */
+export type PackNftContract_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<PackNftContract_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** append existing jsonb value of filtered columns with new jsonb value */
+export type PackNftContract_Append_Input = {
+  eventPassIds?: InputMaybe<Scalars['jsonb']>;
+};
+
+/** aggregate avg on columns */
+export type PackNftContract_Avg_Fields = {
+  __typename?: 'packNftContract_avg_fields';
+  rewardsPerPack?: Maybe<Scalars['Float']>;
+};
+
+/** Boolean expression to filter rows from the table "packNftContract". All fields are combined with a logical 'AND'. */
+export type PackNftContract_Bool_Exp = {
+  _and?: InputMaybe<Array<PackNftContract_Bool_Exp>>;
+  _not?: InputMaybe<PackNftContract_Bool_Exp>;
+  _or?: InputMaybe<Array<PackNftContract_Bool_Exp>>;
+  chainId?: InputMaybe<String_Comparison_Exp>;
+  contractAddress?: InputMaybe<String_Comparison_Exp>;
+  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  eventId?: InputMaybe<String_Comparison_Exp>;
+  eventPassIds?: InputMaybe<Jsonb_Comparison_Exp>;
+  eventPassNfts?: InputMaybe<EventPassNft_Bool_Exp>;
+  eventPassNfts_aggregate?: InputMaybe<EventPassNft_Aggregate_Bool_Exp>;
+  id?: InputMaybe<Uuid_Comparison_Exp>;
+  organizerId?: InputMaybe<String_Comparison_Exp>;
+  packId?: InputMaybe<String_Comparison_Exp>;
+  rewardsPerPack?: InputMaybe<Int_Comparison_Exp>;
+  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "packNftContract" */
+export const enum PackNftContract_Constraint {
+  /** unique or primary key constraint on columns "chainId", "contractAddress" */
+  PackNftContractContractAddressChainIdKey = 'packNftContract_contractAddress_chainId_key',
+  /** unique or primary key constraint on columns "id" */
+  PackNftContractPkey = 'packNftContract_pkey'
+};
+
+/** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+export type PackNftContract_Delete_At_Path_Input = {
+  eventPassIds?: InputMaybe<Array<Scalars['String']>>;
+};
+
+/** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+export type PackNftContract_Delete_Elem_Input = {
+  eventPassIds?: InputMaybe<Scalars['Int']>;
+};
+
+/** delete key/value pair or string element. key/value pairs are matched based on their key value */
+export type PackNftContract_Delete_Key_Input = {
+  eventPassIds?: InputMaybe<Scalars['String']>;
+};
+
+/** input type for incrementing numeric columns in table "packNftContract" */
+export type PackNftContract_Inc_Input = {
+  rewardsPerPack?: InputMaybe<Scalars['Int']>;
+};
+
+/** input type for inserting data into table "packNftContract" */
+export type PackNftContract_Insert_Input = {
+  chainId?: InputMaybe<Scalars['String']>;
+  contractAddress?: InputMaybe<Scalars['String']>;
+  created_at?: InputMaybe<Scalars['timestamptz']>;
+  eventId?: InputMaybe<Scalars['String']>;
+  eventPassIds?: InputMaybe<Scalars['jsonb']>;
+  eventPassNfts?: InputMaybe<EventPassNft_Arr_Rel_Insert_Input>;
+  id?: InputMaybe<Scalars['uuid']>;
+  organizerId?: InputMaybe<Scalars['String']>;
+  packId?: InputMaybe<Scalars['String']>;
+  rewardsPerPack?: InputMaybe<Scalars['Int']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']>;
+};
+
+/** aggregate max on columns */
+export type PackNftContract_Max_Fields = {
+  __typename?: 'packNftContract_max_fields';
+  chainId?: Maybe<Scalars['String']>;
+  contractAddress?: Maybe<Scalars['String']>;
+  created_at?: Maybe<Scalars['timestamptz']>;
+  eventId?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['uuid']>;
+  organizerId?: Maybe<Scalars['String']>;
+  packId?: Maybe<Scalars['String']>;
+  rewardsPerPack?: Maybe<Scalars['Int']>;
+  updated_at?: Maybe<Scalars['timestamptz']>;
+};
+
+/** aggregate min on columns */
+export type PackNftContract_Min_Fields = {
+  __typename?: 'packNftContract_min_fields';
+  chainId?: Maybe<Scalars['String']>;
+  contractAddress?: Maybe<Scalars['String']>;
+  created_at?: Maybe<Scalars['timestamptz']>;
+  eventId?: Maybe<Scalars['String']>;
+  id?: Maybe<Scalars['uuid']>;
+  organizerId?: Maybe<Scalars['String']>;
+  packId?: Maybe<Scalars['String']>;
+  rewardsPerPack?: Maybe<Scalars['Int']>;
+  updated_at?: Maybe<Scalars['timestamptz']>;
+};
+
+/** response of any mutation on the table "packNftContract" */
+export type PackNftContract_Mutation_Response = {
+  __typename?: 'packNftContract_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data from the rows affected by the mutation */
+  returning: Array<PackNftContract>;
+};
+
+/** on_conflict condition type for table "packNftContract" */
+export type PackNftContract_On_Conflict = {
+  constraint: PackNftContract_Constraint;
+  update_columns?: Array<PackNftContract_Update_Column>;
+  where?: InputMaybe<PackNftContract_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "packNftContract". */
+export type PackNftContract_Order_By = {
+  chainId?: InputMaybe<Order_By>;
+  contractAddress?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  eventId?: InputMaybe<Order_By>;
+  eventPassIds?: InputMaybe<Order_By>;
+  eventPassNfts_aggregate?: InputMaybe<EventPassNft_Aggregate_Order_By>;
+  id?: InputMaybe<Order_By>;
+  organizerId?: InputMaybe<Order_By>;
+  packId?: InputMaybe<Order_By>;
+  rewardsPerPack?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: packNftContract */
+export type PackNftContract_Pk_Columns_Input = {
+  id: Scalars['uuid'];
+};
+
+/** prepend existing jsonb value of filtered columns with new jsonb value */
+export type PackNftContract_Prepend_Input = {
+  eventPassIds?: InputMaybe<Scalars['jsonb']>;
+};
+
+/** select columns of table "packNftContract" */
+export const enum PackNftContract_Select_Column {
+  /** column name */
+  ChainId = 'chainId',
+  /** column name */
+  ContractAddress = 'contractAddress',
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  EventId = 'eventId',
+  /** column name */
+  EventPassIds = 'eventPassIds',
+  /** column name */
+  Id = 'id',
+  /** column name */
+  OrganizerId = 'organizerId',
+  /** column name */
+  PackId = 'packId',
+  /** column name */
+  RewardsPerPack = 'rewardsPerPack',
+  /** column name */
+  UpdatedAt = 'updated_at'
+};
+
+/** input type for updating data in table "packNftContract" */
+export type PackNftContract_Set_Input = {
+  chainId?: InputMaybe<Scalars['String']>;
+  contractAddress?: InputMaybe<Scalars['String']>;
+  created_at?: InputMaybe<Scalars['timestamptz']>;
+  eventId?: InputMaybe<Scalars['String']>;
+  eventPassIds?: InputMaybe<Scalars['jsonb']>;
+  id?: InputMaybe<Scalars['uuid']>;
+  organizerId?: InputMaybe<Scalars['String']>;
+  packId?: InputMaybe<Scalars['String']>;
+  rewardsPerPack?: InputMaybe<Scalars['Int']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']>;
+};
+
+/** aggregate stddev on columns */
+export type PackNftContract_Stddev_Fields = {
+  __typename?: 'packNftContract_stddev_fields';
+  rewardsPerPack?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type PackNftContract_Stddev_Pop_Fields = {
+  __typename?: 'packNftContract_stddev_pop_fields';
+  rewardsPerPack?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type PackNftContract_Stddev_Samp_Fields = {
+  __typename?: 'packNftContract_stddev_samp_fields';
+  rewardsPerPack?: Maybe<Scalars['Float']>;
+};
+
+/** Streaming cursor of the table "packNftContract" */
+export type PackNftContract_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: PackNftContract_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type PackNftContract_Stream_Cursor_Value_Input = {
+  chainId?: InputMaybe<Scalars['String']>;
+  contractAddress?: InputMaybe<Scalars['String']>;
+  created_at?: InputMaybe<Scalars['timestamptz']>;
+  eventId?: InputMaybe<Scalars['String']>;
+  eventPassIds?: InputMaybe<Scalars['jsonb']>;
+  id?: InputMaybe<Scalars['uuid']>;
+  organizerId?: InputMaybe<Scalars['String']>;
+  packId?: InputMaybe<Scalars['String']>;
+  rewardsPerPack?: InputMaybe<Scalars['Int']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']>;
+};
+
+/** aggregate sum on columns */
+export type PackNftContract_Sum_Fields = {
+  __typename?: 'packNftContract_sum_fields';
+  rewardsPerPack?: Maybe<Scalars['Int']>;
+};
+
+/** update columns of table "packNftContract" */
+export const enum PackNftContract_Update_Column {
+  /** column name */
+  ChainId = 'chainId',
+  /** column name */
+  ContractAddress = 'contractAddress',
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  EventId = 'eventId',
+  /** column name */
+  EventPassIds = 'eventPassIds',
+  /** column name */
+  Id = 'id',
+  /** column name */
+  OrganizerId = 'organizerId',
+  /** column name */
+  PackId = 'packId',
+  /** column name */
+  RewardsPerPack = 'rewardsPerPack',
+  /** column name */
+  UpdatedAt = 'updated_at'
+};
+
+export type PackNftContract_Updates = {
+  /** append existing jsonb value of filtered columns with new jsonb value */
+  _append?: InputMaybe<PackNftContract_Append_Input>;
+  /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+  _delete_at_path?: InputMaybe<PackNftContract_Delete_At_Path_Input>;
+  /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+  _delete_elem?: InputMaybe<PackNftContract_Delete_Elem_Input>;
+  /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+  _delete_key?: InputMaybe<PackNftContract_Delete_Key_Input>;
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<PackNftContract_Inc_Input>;
+  /** prepend existing jsonb value of filtered columns with new jsonb value */
+  _prepend?: InputMaybe<PackNftContract_Prepend_Input>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<PackNftContract_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: PackNftContract_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type PackNftContract_Var_Pop_Fields = {
+  __typename?: 'packNftContract_var_pop_fields';
+  rewardsPerPack?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate var_samp on columns */
+export type PackNftContract_Var_Samp_Fields = {
+  __typename?: 'packNftContract_var_samp_fields';
+  rewardsPerPack?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate variance on columns */
+export type PackNftContract_Variance_Fields = {
+  __typename?: 'packNftContract_variance_fields';
+  rewardsPerPack?: Maybe<Scalars['Float']>;
+};
+
 export type Query_Root = {
   __typename?: 'query_root';
   /** fetch data from the table: "account" */
@@ -13424,6 +13872,12 @@ export type Query_Root = {
   organizers: Array<Organizer>;
   /** Retrieve multiple organizers using the Relay connection interface */
   organizersConnection: OrganizerConnection;
+  /** fetch data from the table: "packNftContract" */
+  packNftContract: Array<PackNftContract>;
+  /** fetch aggregated fields from the table: "packNftContract" */
+  packNftContract_aggregate: PackNftContract_Aggregate;
+  /** fetch data from the table: "packNftContract" using primary key columns */
+  packNftContract_by_pk?: Maybe<PackNftContract>;
   /** fetch data from the table: "roleAssignments" */
   roleAssignments: Array<RoleAssignments>;
   /** fetch aggregated fields from the table: "roleAssignments" */
@@ -14065,6 +14519,29 @@ export type Query_RootOrganizersConnectionArgs = {
   skip?: InputMaybe<Scalars['Int']>;
   stage?: Stage;
   where?: InputMaybe<OrganizerWhereInput>;
+};
+
+
+export type Query_RootPackNftContractArgs = {
+  distinct_on?: InputMaybe<Array<PackNftContract_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<PackNftContract_Order_By>>;
+  where?: InputMaybe<PackNftContract_Bool_Exp>;
+};
+
+
+export type Query_RootPackNftContract_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<PackNftContract_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<PackNftContract_Order_By>>;
+  where?: InputMaybe<PackNftContract_Bool_Exp>;
+};
+
+
+export type Query_RootPackNftContract_By_PkArgs = {
+  id: Scalars['uuid'];
 };
 
 
@@ -15444,6 +15921,14 @@ export type Subscription_Root = {
   orderStatus_by_pk?: Maybe<OrderStatus>;
   /** fetch data from the table in a streaming manner: "orderStatus" */
   orderStatus_stream: Array<OrderStatus>;
+  /** fetch data from the table: "packNftContract" */
+  packNftContract: Array<PackNftContract>;
+  /** fetch aggregated fields from the table: "packNftContract" */
+  packNftContract_aggregate: PackNftContract_Aggregate;
+  /** fetch data from the table: "packNftContract" using primary key columns */
+  packNftContract_by_pk?: Maybe<PackNftContract>;
+  /** fetch data from the table in a streaming manner: "packNftContract" */
+  packNftContract_stream: Array<PackNftContract>;
   /** fetch data from the table: "roleAssignments" */
   roleAssignments: Array<RoleAssignments>;
   /** fetch aggregated fields from the table: "roleAssignments" */
@@ -15996,6 +16481,36 @@ export type Subscription_RootOrderStatus_StreamArgs = {
   batch_size: Scalars['Int'];
   cursor: Array<InputMaybe<OrderStatus_Stream_Cursor_Input>>;
   where?: InputMaybe<OrderStatus_Bool_Exp>;
+};
+
+
+export type Subscription_RootPackNftContractArgs = {
+  distinct_on?: InputMaybe<Array<PackNftContract_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<PackNftContract_Order_By>>;
+  where?: InputMaybe<PackNftContract_Bool_Exp>;
+};
+
+
+export type Subscription_RootPackNftContract_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<PackNftContract_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<PackNftContract_Order_By>>;
+  where?: InputMaybe<PackNftContract_Bool_Exp>;
+};
+
+
+export type Subscription_RootPackNftContract_By_PkArgs = {
+  id: Scalars['uuid'];
+};
+
+
+export type Subscription_RootPackNftContract_StreamArgs = {
+  batch_size: Scalars['Int'];
+  cursor: Array<InputMaybe<PackNftContract_Stream_Cursor_Input>>;
+  where?: InputMaybe<PackNftContract_Bool_Exp>;
 };
 
 

--- a/libs/gql/shared/types/src/generated/index.ts
+++ b/libs/gql/shared/types/src/generated/index.ts
@@ -7063,6 +7063,8 @@ export type EventPassNft = {
   organizer?: Maybe<Organizer>;
   /** Ties the event pass NFT to a specific organizer within the platform */
   organizerId: Scalars['String'];
+  /** An object relationship */
+  packNftContract?: Maybe<PackNftContract>;
   packNftContractId?: Maybe<Scalars['uuid']>;
   /** The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms. */
   tokenId: Scalars['bigint'];
@@ -7437,7 +7439,7 @@ export type EventPassNftContract_Bool_Exp = {
 /** unique or primary key constraints on table "eventPassNftContract" */
 export const enum EventPassNftContract_Constraint {
   /** unique or primary key constraint on columns "chainId", "contractAddress" */
-  EventPassNftContractChainIdContractAddressKey = 'eventPassNftContract_chainId_contractAddress_key'
+  EventPassNftContractContractAddressChainIdKey = 'eventPassNftContract_contractAddress_chainId_key'
 };
 
 /** input type for inserting data into table "eventPassNftContract" */
@@ -7827,6 +7829,7 @@ export type EventPassNft_Bool_Exp = {
   nftTransfers?: InputMaybe<NftTransfer_Bool_Exp>;
   nftTransfers_aggregate?: InputMaybe<NftTransfer_Aggregate_Bool_Exp>;
   organizerId?: InputMaybe<String_Comparison_Exp>;
+  packNftContract?: InputMaybe<PackNftContract_Bool_Exp>;
   packNftContractId?: InputMaybe<Uuid_Comparison_Exp>;
   tokenId?: InputMaybe<Bigint_Comparison_Exp>;
   tokenUri?: InputMaybe<String_Comparison_Exp>;
@@ -7896,6 +7899,7 @@ export type EventPassNft_Insert_Input = {
   nftTransfers?: InputMaybe<NftTransfer_Arr_Rel_Insert_Input>;
   /** Ties the event pass NFT to a specific organizer within the platform */
   organizerId?: InputMaybe<Scalars['String']>;
+  packNftContract?: InputMaybe<PackNftContract_Obj_Rel_Insert_Input>;
   packNftContractId?: InputMaybe<Scalars['uuid']>;
   /** The unique identifier of the event pass NFT within its specific collection or contract. This remains constant across various platforms. */
   tokenId?: InputMaybe<Scalars['bigint']>;
@@ -8053,6 +8057,7 @@ export type EventPassNft_Order_By = {
   metadata?: InputMaybe<Order_By>;
   nftTransfers_aggregate?: InputMaybe<NftTransfer_Aggregate_Order_By>;
   organizerId?: InputMaybe<Order_By>;
+  packNftContract?: InputMaybe<PackNftContract_Order_By>;
   packNftContractId?: InputMaybe<Order_By>;
   tokenId?: InputMaybe<Order_By>;
   tokenUri?: InputMaybe<Order_By>;
@@ -13547,6 +13552,13 @@ export type PackNftContract_Mutation_Response = {
   affected_rows: Scalars['Int'];
   /** data from the rows affected by the mutation */
   returning: Array<PackNftContract>;
+};
+
+/** input type for inserting object relation for remote table "packNftContract" */
+export type PackNftContract_Obj_Rel_Insert_Input = {
+  data: PackNftContract_Insert_Input;
+  /** upsert condition */
+  on_conflict?: InputMaybe<PackNftContract_On_Conflict>;
 };
 
 /** on_conflict condition type for table "packNftContract" */

--- a/libs/nft/thirdweb-organizer/src/action.ts
+++ b/libs/nft/thirdweb-organizer/src/action.ts
@@ -18,6 +18,7 @@ import type {
   EventPassNft_Insert_Input,
 } from '@gql/shared/types';
 import { defaultLocale } from '@next/i18n';
+import { ThirdwebSDK } from '@thirdweb-dev/sdk';
 
 export async function createEventPassNftContract(
   object: EventPassNftContract_Insert_Input,
@@ -77,4 +78,12 @@ export async function createEventParametersAndWebhook({
       },
     ]);
   }
+}
+
+export async function getUnopenedNftPackAmount(contractAddress: string) {
+  const sdk = new ThirdwebSDK('goerli');
+  const contract = await sdk.getContract(contractAddress, 'pack');
+  const packId = 0;
+  const contents = await contract.getPackContents(packId);
+  return contents.erc721Rewards;
 }


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR introduces several enhancements to the codebase:
- A new model, `packNftContract`, has been developed to manage the NFTs associated with each pack. This model includes fields such as `chainId`, `contractAddress`, `eventId`, `organizerId`, `packId`, and `rewardsPerPack`.
- The `eventPassNft` model has been updated with a new field `packNftContractId`.
- A new function, `getUnopenedNftPackAmount`, has been added to the `action.ts` file. This function uses the ThirdwebSDK to interact with the contract and retrieve the amount of unopened NFT packs.
- The GraphQL schema has been updated to reflect these changes, including new queries, mutations, and subscriptions related to the `packNftContract` model.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>action.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        libs/nft/thirdweb-organizer/src/action.ts<br><br>
        <strong>Added a new function `getUnopenedNftPackAmount` that <br>interacts with the contract to retrieve the amount of <br>unopened NFT packs.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/214/files#diff-979b6ef9b050567219e1a772e5d6449136db534623283c47496e746df4235a35"> +9/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>schema.graphql&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        libs/gql/admin/api/src/generated/schema.graphql<br><br>
        <strong>Updated the GraphQL schema to include new queries, <br>mutations, and subscriptions related to the <br>`packNftContract` model. Also, added `packNftContractId` <br>field to the `eventPassNft` model.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/214/files#diff-9c71e85bdaeaa73b2ecbab6ebcc4375ad40f1d9303e348bc6768c8ad73d30bae"> +646/-1</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Database</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>down.sql&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        hasura/app/migrations/default/1702546195591_create_pack_nft_contract_ticket_pk_02/down.sql<br><br>
        <strong>Provided the down migration steps for the changes made in <br>the database schema related to the `packNftContract` model <br>and `eventPassNft` model.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/214/files#diff-ebddadd838cd5f5012ea0465b937d650a8128e619041fee9a72a6fe908b81969"> +18/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>public_packNftContract.yaml&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        hasura/app/metadata/databases/default/tables/public_packNftContract.yaml<br><br>
        <strong>Added metadata for the new `packNftContract` table in the <br>database.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/214/files#diff-4249c6aab6f85aa347549189b0447f54f9ed3a6ac7c131898648ac2ffac9a565"> +16/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>