### PR TITLE
fix: types in nft/types and adjusting tests for currentOwnerAddres re…

### DIFF
--- a/hasura/app/metadata/databases/default/tables/public_packNftSupply.yaml
+++ b/hasura/app/metadata/databases/default/tables/public_packNftSupply.yaml
@@ -1,0 +1,3 @@
+table:
+  name: packNftSupply
+  schema: public

--- a/hasura/app/metadata/databases/default/tables/tables.yaml
+++ b/hasura/app/metadata/databases/default/tables/tables.yaml
@@ -14,6 +14,7 @@
 - "!include public_order.yaml"
 - "!include public_orderStatus.yaml"
 - "!include public_packNftContract.yaml"
+- "!include public_packNftSupply.yaml"
 - "!include public_packOrderSums.yaml"
 - "!include public_passAmount.yaml"
 - "!include public_passPricing.yaml"

--- a/hasura/app/migrations/default/1704880303368_create_packNftSupply/down.sql
+++ b/hasura/app/migrations/default/1704880303368_create_packNftSupply/down.sql
@@ -1,0 +1,49 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- -- Create packNftSupply table
+-- CREATE TABLE "public"."packNftSupply" (
+--   "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+--   "contractAddress" text NOT NULL,
+--   "error" text,
+--   "tokenUri" text,
+--   "chainId" text NOT NULL,
+--   "packId" text NOT NULL,
+--   "organizerId" text NOT NULL,
+--   "currentOwnerAddress" text,
+--   "lastNftTransferId" uuid REFERENCES "public"."nftTransfer"("id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+--   "eventPassNfts" uuid[] NULL,
+--   "redeemableNfts" uuid[] NULL,
+--   "created_at" timestamptz NOT NULL DEFAULT now(),
+--   "updated_at" timestamptz NOT NULL DEFAULT now(),
+--   PRIMARY KEY ("id"),
+--   UNIQUE ("contractAddress", "chainId", "packId")
+-- );
+--
+-- -- Comments for the packNftSupply table and its columns
+-- COMMENT ON TABLE "public"."packNftSupply" IS E'This table represents the supply details of pack NFTs, tracking the ownership, contents, and metadata associated with each pack.';
+--
+-- COMMENT ON COLUMN "public"."packNftSupply"."contractAddress" IS E'The address of the smart contract representing the pack NFT. Essential for blockchain interactions.';
+--
+-- COMMENT ON COLUMN "public"."packNftSupply"."error" IS E'Any error messages related to this pack NFT, particularly during transactions or metadata retrieval.';
+--
+-- COMMENT ON COLUMN "public"."packNftSupply"."tokenUri" IS E'The URI pointing to the metadata of the pack NFT.';
+--
+-- COMMENT ON COLUMN "public"."packNftSupply"."chainId" IS E'The specific blockchain or network on which the pack NFT exists.';
+--
+-- COMMENT ON COLUMN "public"."packNftSupply"."packId" IS E'A unique identifier for the pack within the platform.';
+--
+-- COMMENT ON COLUMN "public"."packNftSupply"."organizerId" IS E'The identifier of the organizer associated with this pack NFT.';
+--
+-- COMMENT ON COLUMN "public"."packNftSupply"."currentOwnerAddress" IS E'The blockchain address of the current owner of the pack NFT.';
+--
+-- COMMENT ON COLUMN "public"."packNftSupply"."lastNftTransferId" IS E'The reference to the latest transfer record for this pack NFT.';
+--
+-- COMMENT ON COLUMN "public"."packNftSupply"."eventPassNfts" IS E'An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened.';
+--
+-- COMMENT ON COLUMN "public"."packNftSupply"."redeemableNfts" IS E'An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened.';
+--
+-- -- Create trigger for packNftSupply
+-- CREATE TRIGGER set_packNftSupply_updated_at
+--   BEFORE UPDATE ON "public"."packNftSupply"
+--   FOR EACH ROW
+--   EXECUTE FUNCTION public.set_current_timestamp_updated_at();

--- a/hasura/app/migrations/default/1704880303368_create_packNftSupply/up.sql
+++ b/hasura/app/migrations/default/1704880303368_create_packNftSupply/up.sql
@@ -1,0 +1,47 @@
+-- Create packNftSupply table
+CREATE TABLE "public"."packNftSupply" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "contractAddress" text NOT NULL,
+  "error" text,
+  "tokenUri" text,
+  "chainId" text NOT NULL,
+  "packId" text NOT NULL,
+  "organizerId" text NOT NULL,
+  "currentOwnerAddress" text,
+  "lastNftTransferId" uuid REFERENCES "public"."nftTransfer"("id") ON UPDATE NO ACTION ON DELETE NO ACTION,
+  "eventPassNfts" uuid[] NULL,
+  "redeemableNfts" uuid[] NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("id"),
+  UNIQUE ("contractAddress", "chainId", "packId")
+);
+
+-- Comments for the packNftSupply table and its columns
+COMMENT ON TABLE "public"."packNftSupply" IS E'This table represents the supply details of pack NFTs, tracking the ownership, contents, and metadata associated with each pack.';
+
+COMMENT ON COLUMN "public"."packNftSupply"."contractAddress" IS E'The address of the smart contract representing the pack NFT. Essential for blockchain interactions.';
+
+COMMENT ON COLUMN "public"."packNftSupply"."error" IS E'Any error messages related to this pack NFT, particularly during transactions or metadata retrieval.';
+
+COMMENT ON COLUMN "public"."packNftSupply"."tokenUri" IS E'The URI pointing to the metadata of the pack NFT.';
+
+COMMENT ON COLUMN "public"."packNftSupply"."chainId" IS E'The specific blockchain or network on which the pack NFT exists.';
+
+COMMENT ON COLUMN "public"."packNftSupply"."packId" IS E'A unique identifier for the pack within the platform.';
+
+COMMENT ON COLUMN "public"."packNftSupply"."organizerId" IS E'The identifier of the organizer associated with this pack NFT.';
+
+COMMENT ON COLUMN "public"."packNftSupply"."currentOwnerAddress" IS E'The blockchain address of the current owner of the pack NFT.';
+
+COMMENT ON COLUMN "public"."packNftSupply"."lastNftTransferId" IS E'The reference to the latest transfer record for this pack NFT.';
+
+COMMENT ON COLUMN "public"."packNftSupply"."eventPassNfts" IS E'An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened.';
+
+COMMENT ON COLUMN "public"."packNftSupply"."redeemableNfts" IS E'An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened.';
+
+-- Create trigger for packNftSupply
+CREATE TRIGGER set_packNftSupply_updated_at
+  BEFORE UPDATE ON "public"."packNftSupply"
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_current_timestamp_updated_at();

--- a/libs/gql/admin/api/src/generated/index.ts
+++ b/libs/gql/admin/api/src/generated/index.ts
@@ -809,6 +809,35 @@ ${EventDateLocationsFieldsFragmentDoc}`;
   }
 }
     `;
+ const UpdatePackNftSupplyManyDocument = `
+    mutation UpdatePackNftSupplyMany($updates: [packNftSupply_updates!]!) {
+  update_packNftSupply_many(updates: $updates) {
+    affected_rows
+    returning {
+      id
+      contractAddress
+      currentOwnerAddress
+    }
+  }
+}
+    `;
+ const CreatePackNftSupplyDocument = `
+    mutation CreatePackNftSupply($objects: [packNftSupply_insert_input!]!) {
+  insert_packNftSupply(objects: $objects) {
+    affected_rows
+  }
+}
+    `;
+ const GetPackNftSupplyWithNullNftsFromCurrentOwnerAddressDocument = `
+    query GetPackNftSupplyWithNullNftsFromCurrentOwnerAddress($contractAddress: String!, $currentOwnerAddress: String!) {
+  packNftSupply(
+    where: {redeemableNfts: {_is_null: true}, eventPassNfts: {_is_null: true}, contractAddress: {_eq: $contractAddress}, currentOwnerAddress: {_eq: $currentOwnerAddress}}
+  ) {
+    id
+    organizerId
+  }
+}
+    `;
  const CreatePassAmountDocument = `
     mutation CreatePassAmount($passAmount: passAmount_insert_input!) {
   insert_passAmount_one(object: $passAmount) {
@@ -1170,6 +1199,15 @@ export function getSdk<C, E>(requester: Requester<C, E>) {
     },
     GetPackNftContractFromPackId(variables?: Types.GetPackNftContractFromPackIdQueryVariables, options?: C): Promise<Types.GetPackNftContractFromPackIdQuery> {
       return requester<Types.GetPackNftContractFromPackIdQuery, Types.GetPackNftContractFromPackIdQueryVariables>(GetPackNftContractFromPackIdDocument, variables, options) as Promise<Types.GetPackNftContractFromPackIdQuery>;
+    },
+    UpdatePackNftSupplyMany(variables: Types.UpdatePackNftSupplyManyMutationVariables, options?: C): Promise<Types.UpdatePackNftSupplyManyMutation> {
+      return requester<Types.UpdatePackNftSupplyManyMutation, Types.UpdatePackNftSupplyManyMutationVariables>(UpdatePackNftSupplyManyDocument, variables, options) as Promise<Types.UpdatePackNftSupplyManyMutation>;
+    },
+    CreatePackNftSupply(variables: Types.CreatePackNftSupplyMutationVariables, options?: C): Promise<Types.CreatePackNftSupplyMutation> {
+      return requester<Types.CreatePackNftSupplyMutation, Types.CreatePackNftSupplyMutationVariables>(CreatePackNftSupplyDocument, variables, options) as Promise<Types.CreatePackNftSupplyMutation>;
+    },
+    GetPackNftSupplyWithNullNftsFromCurrentOwnerAddress(variables: Types.GetPackNftSupplyWithNullNftsFromCurrentOwnerAddressQueryVariables, options?: C): Promise<Types.GetPackNftSupplyWithNullNftsFromCurrentOwnerAddressQuery> {
+      return requester<Types.GetPackNftSupplyWithNullNftsFromCurrentOwnerAddressQuery, Types.GetPackNftSupplyWithNullNftsFromCurrentOwnerAddressQueryVariables>(GetPackNftSupplyWithNullNftsFromCurrentOwnerAddressDocument, variables, options) as Promise<Types.GetPackNftSupplyWithNullNftsFromCurrentOwnerAddressQuery>;
     },
     CreatePassAmount(variables: Types.CreatePassAmountMutationVariables, options?: C): Promise<Types.CreatePassAmountMutation> {
       return requester<Types.CreatePassAmountMutation, Types.CreatePassAmountMutationVariables>(CreatePassAmountDocument, variables, options) as Promise<Types.CreatePassAmountMutation>;

--- a/libs/gql/admin/api/src/generated/index.ts
+++ b/libs/gql/admin/api/src/generated/index.ts
@@ -708,6 +708,16 @@ ${EventDateLocationsFieldsFragmentDoc}`;
   }
 }
     `;
+ const GetCurrentOwnerAddressByContractAndTokenIdDocument = `
+    query GetCurrentOwnerAddressByContractAndTokenId($contractAddress: String!, $tokenId: bigint!) {
+  eventPassNft(
+    where: {contractAddress: {_eq: $contractAddress}, tokenId: {_eq: $tokenId}}
+  ) {
+    id
+    currentOwnerAddress
+  }
+}
+    `;
  const CreateEventPassNftContractDocument = `
     mutation CreateEventPassNftContract($object: eventPassNftContract_insert_input!) {
   insert_eventPassNftContract_one(object: $object) {
@@ -1172,6 +1182,9 @@ export function getSdk<C, E>(requester: Requester<C, E>) {
     },
     GetListCurrentOwnerAddressForContractAddress(variables?: Types.GetListCurrentOwnerAddressForContractAddressQueryVariables, options?: C): Promise<Types.GetListCurrentOwnerAddressForContractAddressQuery> {
       return requester<Types.GetListCurrentOwnerAddressForContractAddressQuery, Types.GetListCurrentOwnerAddressForContractAddressQueryVariables>(GetListCurrentOwnerAddressForContractAddressDocument, variables, options) as Promise<Types.GetListCurrentOwnerAddressForContractAddressQuery>;
+    },
+    GetCurrentOwnerAddressByContractAndTokenId(variables: Types.GetCurrentOwnerAddressByContractAndTokenIdQueryVariables, options?: C): Promise<Types.GetCurrentOwnerAddressByContractAndTokenIdQuery> {
+      return requester<Types.GetCurrentOwnerAddressByContractAndTokenIdQuery, Types.GetCurrentOwnerAddressByContractAndTokenIdQueryVariables>(GetCurrentOwnerAddressByContractAndTokenIdDocument, variables, options) as Promise<Types.GetCurrentOwnerAddressByContractAndTokenIdQuery>;
     },
     CreateEventPassNftContract(variables: Types.CreateEventPassNftContractMutationVariables, options?: C): Promise<Types.CreateEventPassNftContractMutation> {
       return requester<Types.CreateEventPassNftContractMutation, Types.CreateEventPassNftContractMutationVariables>(CreateEventPassNftContractDocument, variables, options) as Promise<Types.CreateEventPassNftContractMutation>;

--- a/libs/gql/admin/api/src/generated/schema.graphql
+++ b/libs/gql/admin/api/src/generated/schema.graphql
@@ -1636,10 +1636,10 @@ input EventCreateOneInlineInput {
 Model used to define the different locations and dates of an event. A festival or a tournament for instance could have several.
 """
 type EventDateLocation implements Entity {
-  """The end date including time on the UTC timezone."""
+  """The end date including time."""
   dateEnd: DateTime!
 
-  """The start date including time on the UTC timezone."""
+  """The start date including time."""
   dateStart: DateTime!
 
   """The unique identifier"""
@@ -5313,6 +5313,7 @@ type OrganizerConnection {
 }
 
 input OrganizerCreateInput {
+  clr7j9mmt0q2j01uo9zrs2fm7: PackCreateManyInlineInput
   createdAt: DateTime
 
   """description input for default locale (en)"""
@@ -5862,6 +5863,8 @@ enum OrganizerOrderByInput {
 }
 
 input OrganizerUpdateInput {
+  clr7j9mmt0q2j01uo9zrs2fm7: PackUpdateManyInlineInput
+
   """description input for default locale (en)"""
   description: RichTextAST
   discordWidgetId: String
@@ -6654,6 +6657,27 @@ type Pack implements Entity & Node {
   Permanent name associated with the NFT. Cannot be changed or localized.
   """
   nftName: String!
+  organizer(
+    """
+    Sets the locale of the parent document as the first locale in the fallback locales in the query's subtree.
+    
+    Note that `organizer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, localized entries that do not have the provided locale defined will be filtered out.
+    
+    This argument will affect any existing locale filtering defined in the query's tree for the subtree.
+    """
+    forceParentLocale: Boolean
+
+    """
+    Allows to optionally override locale filtering behaviour in the query's subtree.
+    
+    Note that `organizer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, localized entries that do not have the provided locale defined will be filtered out.
+    
+    This argument will overwrite any existing locale filtering defined in the query's tree for the subtree.
+    """
+    locales: [Locale!]
+  ): Organizer
 
   """The time the document was published. Null on documents in draft stage."""
   publishedAt(
@@ -6787,6 +6811,7 @@ input PackCreateInput {
   nftDescription: String!
   nftImage: AssetCreateOneInlineInput!
   nftName: String!
+  organizer: OrganizerCreateOneInlineInput
   updatedAt: DateTime
 }
 
@@ -7024,6 +7049,7 @@ input PackManyWhereInput {
 
   """All values starting with the given string."""
   nftName_starts_with: String
+  organizer: OrganizerWhereInput
   publishedAt: DateTime
 
   """All values greater than the given value."""
@@ -7107,6 +7133,7 @@ input PackUpdateInput {
   nftDescription: String
   nftImage: AssetUpdateOneInlineInput
   nftName: String
+  organizer: OrganizerUpdateOneInlineInput
 }
 
 input PackUpdateLocalizationDataInput {
@@ -7432,6 +7459,7 @@ input PackWhereInput {
 
   """All values starting with the given string."""
   nftName_starts_with: String
+  organizer: OrganizerWhereInput
   publishedAt: DateTime
 
   """All values greater than the given value."""
@@ -7537,10 +7565,7 @@ type PassOption implements Entity {
   """
   description: String
 
-  """
-  Define the location and date for this option.
-  Important ! It will determine the release and availability for the Pass access.
-  """
+  """Define the location and date for this option."""
   eventDateLocation(
     """
     Sets the locale of the resolved parent document as the only locale in the query's subtree.
@@ -13823,6 +13848,19 @@ type mutation_root {
   delete_packNftContract_by_pk(id: uuid!): packNftContract
 
   """
+  delete data from the table: "packNftSupply"
+  """
+  delete_packNftSupply(
+    """filter the rows which have to be deleted"""
+    where: packNftSupply_bool_exp!
+  ): packNftSupply_mutation_response
+
+  """
+  delete single row from the table: "packNftSupply"
+  """
+  delete_packNftSupply_by_pk(id: uuid!): packNftSupply
+
+  """
   delete data from the table: "packOrderSums"
   """
   delete_packOrderSums(
@@ -14310,6 +14348,28 @@ type mutation_root {
     """upsert condition"""
     on_conflict: packNftContract_on_conflict
   ): packNftContract
+
+  """
+  insert data into the table: "packNftSupply"
+  """
+  insert_packNftSupply(
+    """the rows to be inserted"""
+    objects: [packNftSupply_insert_input!]!
+
+    """upsert condition"""
+    on_conflict: packNftSupply_on_conflict
+  ): packNftSupply_mutation_response
+
+  """
+  insert a single row into the table: "packNftSupply"
+  """
+  insert_packNftSupply_one(
+    """the row to be inserted"""
+    object: packNftSupply_insert_input!
+
+    """upsert condition"""
+    on_conflict: packNftSupply_on_conflict
+  ): packNftSupply
 
   """
   insert data into the table: "packOrderSums"
@@ -16337,6 +16397,34 @@ type mutation_root {
     """updates to execute, in order"""
     updates: [packNftContract_updates!]!
   ): [packNftContract_mutation_response]
+
+  """
+  update data of the table: "packNftSupply"
+  """
+  update_packNftSupply(
+    """sets the columns of the filtered rows to the given values"""
+    _set: packNftSupply_set_input
+
+    """filter the rows which have to be updated"""
+    where: packNftSupply_bool_exp!
+  ): packNftSupply_mutation_response
+
+  """
+  update single row of the table: "packNftSupply"
+  """
+  update_packNftSupply_by_pk(
+    """sets the columns of the filtered rows to the given values"""
+    _set: packNftSupply_set_input
+    pk_columns: packNftSupply_pk_columns_input!
+  ): packNftSupply
+
+  """
+  update multiples rows of table: "packNftSupply"
+  """
+  update_packNftSupply_many(
+    """updates to execute, in order"""
+    updates: [packNftSupply_updates!]!
+  ): [packNftSupply_mutation_response]
 
   """
   update data of the table: "packOrderSums"
@@ -18863,6 +18951,479 @@ type packNftContract_variance_fields {
   rewardsPerPack: Float
 }
 
+"""
+This table represents the supply details of pack NFTs, tracking the ownership, contents, and metadata associated with each pack.
+"""
+type packNftSupply {
+  """The specific blockchain or network on which the pack NFT exists."""
+  chainId: String!
+
+  """
+  The address of the smart contract representing the pack NFT. Essential for blockchain interactions.
+  """
+  contractAddress: String!
+  created_at: timestamptz!
+
+  """The blockchain address of the current owner of the pack NFT."""
+  currentOwnerAddress: String
+
+  """
+  Any error messages related to this pack NFT, particularly during transactions or metadata retrieval.
+  """
+  error: String
+
+  """
+  An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened.
+  """
+  eventPassNfts: [uuid!]
+  id: uuid!
+
+  """The reference to the latest transfer record for this pack NFT."""
+  lastNftTransferId: uuid
+
+  """The identifier of the organizer associated with this pack NFT."""
+  organizerId: String!
+
+  """A unique identifier for the pack within the platform."""
+  packId: String!
+
+  """
+  An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened.
+  """
+  redeemableNfts: [uuid!]
+
+  """The URI pointing to the metadata of the pack NFT."""
+  tokenUri: String
+  updated_at: timestamptz!
+}
+
+"""
+aggregated selection of "packNftSupply"
+"""
+type packNftSupply_aggregate {
+  aggregate: packNftSupply_aggregate_fields
+  nodes: [packNftSupply!]!
+}
+
+"""
+aggregate fields of "packNftSupply"
+"""
+type packNftSupply_aggregate_fields {
+  count(columns: [packNftSupply_select_column!], distinct: Boolean): Int!
+  max: packNftSupply_max_fields
+  min: packNftSupply_min_fields
+}
+
+"""
+Boolean expression to filter rows from the table "packNftSupply". All fields are combined with a logical 'AND'.
+"""
+input packNftSupply_bool_exp {
+  _and: [packNftSupply_bool_exp!]
+  _not: packNftSupply_bool_exp
+  _or: [packNftSupply_bool_exp!]
+  chainId: String_comparison_exp
+  contractAddress: String_comparison_exp
+  created_at: timestamptz_comparison_exp
+  currentOwnerAddress: String_comparison_exp
+  error: String_comparison_exp
+  eventPassNfts: uuid_array_comparison_exp
+  id: uuid_comparison_exp
+  lastNftTransferId: uuid_comparison_exp
+  organizerId: String_comparison_exp
+  packId: String_comparison_exp
+  redeemableNfts: uuid_array_comparison_exp
+  tokenUri: String_comparison_exp
+  updated_at: timestamptz_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "packNftSupply"
+"""
+enum packNftSupply_constraint {
+  """
+  unique or primary key constraint on columns "chainId", "contractAddress", "packId"
+  """
+  packNftSupply_contractAddress_chainId_packId_key
+
+  """
+  unique or primary key constraint on columns "id"
+  """
+  packNftSupply_pkey
+}
+
+"""
+input type for inserting data into table "packNftSupply"
+"""
+input packNftSupply_insert_input {
+  """The specific blockchain or network on which the pack NFT exists."""
+  chainId: String
+
+  """
+  The address of the smart contract representing the pack NFT. Essential for blockchain interactions.
+  """
+  contractAddress: String
+  created_at: timestamptz
+
+  """The blockchain address of the current owner of the pack NFT."""
+  currentOwnerAddress: String
+
+  """
+  Any error messages related to this pack NFT, particularly during transactions or metadata retrieval.
+  """
+  error: String
+
+  """
+  An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened.
+  """
+  eventPassNfts: [uuid!]
+  id: uuid
+
+  """The reference to the latest transfer record for this pack NFT."""
+  lastNftTransferId: uuid
+
+  """The identifier of the organizer associated with this pack NFT."""
+  organizerId: String
+
+  """A unique identifier for the pack within the platform."""
+  packId: String
+
+  """
+  An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened.
+  """
+  redeemableNfts: [uuid!]
+
+  """The URI pointing to the metadata of the pack NFT."""
+  tokenUri: String
+  updated_at: timestamptz
+}
+
+"""aggregate max on columns"""
+type packNftSupply_max_fields {
+  """The specific blockchain or network on which the pack NFT exists."""
+  chainId: String
+
+  """
+  The address of the smart contract representing the pack NFT. Essential for blockchain interactions.
+  """
+  contractAddress: String
+  created_at: timestamptz
+
+  """The blockchain address of the current owner of the pack NFT."""
+  currentOwnerAddress: String
+
+  """
+  Any error messages related to this pack NFT, particularly during transactions or metadata retrieval.
+  """
+  error: String
+
+  """
+  An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened.
+  """
+  eventPassNfts: [uuid!]
+  id: uuid
+
+  """The reference to the latest transfer record for this pack NFT."""
+  lastNftTransferId: uuid
+
+  """The identifier of the organizer associated with this pack NFT."""
+  organizerId: String
+
+  """A unique identifier for the pack within the platform."""
+  packId: String
+
+  """
+  An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened.
+  """
+  redeemableNfts: [uuid!]
+
+  """The URI pointing to the metadata of the pack NFT."""
+  tokenUri: String
+  updated_at: timestamptz
+}
+
+"""aggregate min on columns"""
+type packNftSupply_min_fields {
+  """The specific blockchain or network on which the pack NFT exists."""
+  chainId: String
+
+  """
+  The address of the smart contract representing the pack NFT. Essential for blockchain interactions.
+  """
+  contractAddress: String
+  created_at: timestamptz
+
+  """The blockchain address of the current owner of the pack NFT."""
+  currentOwnerAddress: String
+
+  """
+  Any error messages related to this pack NFT, particularly during transactions or metadata retrieval.
+  """
+  error: String
+
+  """
+  An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened.
+  """
+  eventPassNfts: [uuid!]
+  id: uuid
+
+  """The reference to the latest transfer record for this pack NFT."""
+  lastNftTransferId: uuid
+
+  """The identifier of the organizer associated with this pack NFT."""
+  organizerId: String
+
+  """A unique identifier for the pack within the platform."""
+  packId: String
+
+  """
+  An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened.
+  """
+  redeemableNfts: [uuid!]
+
+  """The URI pointing to the metadata of the pack NFT."""
+  tokenUri: String
+  updated_at: timestamptz
+}
+
+"""
+response of any mutation on the table "packNftSupply"
+"""
+type packNftSupply_mutation_response {
+  """number of rows affected by the mutation"""
+  affected_rows: Int!
+
+  """data from the rows affected by the mutation"""
+  returning: [packNftSupply!]!
+}
+
+"""
+on_conflict condition type for table "packNftSupply"
+"""
+input packNftSupply_on_conflict {
+  constraint: packNftSupply_constraint!
+  update_columns: [packNftSupply_update_column!]! = []
+  where: packNftSupply_bool_exp
+}
+
+"""Ordering options when selecting data from "packNftSupply"."""
+input packNftSupply_order_by {
+  chainId: order_by
+  contractAddress: order_by
+  created_at: order_by
+  currentOwnerAddress: order_by
+  error: order_by
+  eventPassNfts: order_by
+  id: order_by
+  lastNftTransferId: order_by
+  organizerId: order_by
+  packId: order_by
+  redeemableNfts: order_by
+  tokenUri: order_by
+  updated_at: order_by
+}
+
+"""primary key columns input for table: packNftSupply"""
+input packNftSupply_pk_columns_input {
+  id: uuid!
+}
+
+"""
+select columns of table "packNftSupply"
+"""
+enum packNftSupply_select_column {
+  """column name"""
+  chainId
+
+  """column name"""
+  contractAddress
+
+  """column name"""
+  created_at
+
+  """column name"""
+  currentOwnerAddress
+
+  """column name"""
+  error
+
+  """column name"""
+  eventPassNfts
+
+  """column name"""
+  id
+
+  """column name"""
+  lastNftTransferId
+
+  """column name"""
+  organizerId
+
+  """column name"""
+  packId
+
+  """column name"""
+  redeemableNfts
+
+  """column name"""
+  tokenUri
+
+  """column name"""
+  updated_at
+}
+
+"""
+input type for updating data in table "packNftSupply"
+"""
+input packNftSupply_set_input {
+  """The specific blockchain or network on which the pack NFT exists."""
+  chainId: String
+
+  """
+  The address of the smart contract representing the pack NFT. Essential for blockchain interactions.
+  """
+  contractAddress: String
+  created_at: timestamptz
+
+  """The blockchain address of the current owner of the pack NFT."""
+  currentOwnerAddress: String
+
+  """
+  Any error messages related to this pack NFT, particularly during transactions or metadata retrieval.
+  """
+  error: String
+
+  """
+  An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened.
+  """
+  eventPassNfts: [uuid!]
+  id: uuid
+
+  """The reference to the latest transfer record for this pack NFT."""
+  lastNftTransferId: uuid
+
+  """The identifier of the organizer associated with this pack NFT."""
+  organizerId: String
+
+  """A unique identifier for the pack within the platform."""
+  packId: String
+
+  """
+  An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened.
+  """
+  redeemableNfts: [uuid!]
+
+  """The URI pointing to the metadata of the pack NFT."""
+  tokenUri: String
+  updated_at: timestamptz
+}
+
+"""
+Streaming cursor of the table "packNftSupply"
+"""
+input packNftSupply_stream_cursor_input {
+  """Stream column input with initial value"""
+  initial_value: packNftSupply_stream_cursor_value_input!
+
+  """cursor ordering"""
+  ordering: cursor_ordering
+}
+
+"""Initial value of the column from where the streaming should start"""
+input packNftSupply_stream_cursor_value_input {
+  """The specific blockchain or network on which the pack NFT exists."""
+  chainId: String
+
+  """
+  The address of the smart contract representing the pack NFT. Essential for blockchain interactions.
+  """
+  contractAddress: String
+  created_at: timestamptz
+
+  """The blockchain address of the current owner of the pack NFT."""
+  currentOwnerAddress: String
+
+  """
+  Any error messages related to this pack NFT, particularly during transactions or metadata retrieval.
+  """
+  error: String
+
+  """
+  An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened.
+  """
+  eventPassNfts: [uuid!]
+  id: uuid
+
+  """The reference to the latest transfer record for this pack NFT."""
+  lastNftTransferId: uuid
+
+  """The identifier of the organizer associated with this pack NFT."""
+  organizerId: String
+
+  """A unique identifier for the pack within the platform."""
+  packId: String
+
+  """
+  An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened.
+  """
+  redeemableNfts: [uuid!]
+
+  """The URI pointing to the metadata of the pack NFT."""
+  tokenUri: String
+  updated_at: timestamptz
+}
+
+"""
+update columns of table "packNftSupply"
+"""
+enum packNftSupply_update_column {
+  """column name"""
+  chainId
+
+  """column name"""
+  contractAddress
+
+  """column name"""
+  created_at
+
+  """column name"""
+  currentOwnerAddress
+
+  """column name"""
+  error
+
+  """column name"""
+  eventPassNfts
+
+  """column name"""
+  id
+
+  """column name"""
+  lastNftTransferId
+
+  """column name"""
+  organizerId
+
+  """column name"""
+  packId
+
+  """column name"""
+  redeemableNfts
+
+  """column name"""
+  tokenUri
+
+  """column name"""
+  updated_at
+}
+
+input packNftSupply_updates {
+  """sets the columns of the filtered rows to the given values"""
+  _set: packNftSupply_set_input
+
+  """filter the rows which have to be updated"""
+  where: packNftSupply_bool_exp!
+}
+
 """Hold the sums for the Pack Orders"""
 type packOrderSums {
   packId: String!
@@ -21108,6 +21669,49 @@ type query_root {
 
   """fetch data from the table: "packNftContract" using primary key columns"""
   packNftContract_by_pk(id: uuid!): packNftContract
+
+  """
+  fetch data from the table: "packNftSupply"
+  """
+  packNftSupply(
+    """distinct select on columns"""
+    distinct_on: [packNftSupply_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [packNftSupply_order_by!]
+
+    """filter the rows returned"""
+    where: packNftSupply_bool_exp
+  ): [packNftSupply!]!
+
+  """
+  fetch aggregated fields from the table: "packNftSupply"
+  """
+  packNftSupply_aggregate(
+    """distinct select on columns"""
+    distinct_on: [packNftSupply_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [packNftSupply_order_by!]
+
+    """filter the rows returned"""
+    where: packNftSupply_bool_exp
+  ): packNftSupply_aggregate!
+
+  """fetch data from the table: "packNftSupply" using primary key columns"""
+  packNftSupply_by_pk(id: uuid!): packNftSupply
 
   """
   fetch data from the table: "packOrderSums"
@@ -23831,6 +24435,63 @@ type subscription_root {
   ): [packNftContract!]!
 
   """
+  fetch data from the table: "packNftSupply"
+  """
+  packNftSupply(
+    """distinct select on columns"""
+    distinct_on: [packNftSupply_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [packNftSupply_order_by!]
+
+    """filter the rows returned"""
+    where: packNftSupply_bool_exp
+  ): [packNftSupply!]!
+
+  """
+  fetch aggregated fields from the table: "packNftSupply"
+  """
+  packNftSupply_aggregate(
+    """distinct select on columns"""
+    distinct_on: [packNftSupply_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [packNftSupply_order_by!]
+
+    """filter the rows returned"""
+    where: packNftSupply_bool_exp
+  ): packNftSupply_aggregate!
+
+  """fetch data from the table: "packNftSupply" using primary key columns"""
+  packNftSupply_by_pk(id: uuid!): packNftSupply
+
+  """
+  fetch data from the table in a streaming manner: "packNftSupply"
+  """
+  packNftSupply_stream(
+    """maximum number of rows returned in a single batch"""
+    batch_size: Int!
+
+    """cursor to stream the results returned by the query"""
+    cursor: [packNftSupply_stream_cursor_input]!
+
+    """filter the rows returned"""
+    where: packNftSupply_bool_exp
+  ): [packNftSupply!]!
+
+  """
   fetch data from the table: "packOrderSums"
   """
   packOrderSums(
@@ -24585,6 +25246,26 @@ input timezone_updates {
 }
 
 scalar uuid
+
+"""
+Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'.
+"""
+input uuid_array_comparison_exp {
+  """is the array contained in the given array value"""
+  _contained_in: [uuid!]
+
+  """does the array contain the given value"""
+  _contains: [uuid!]
+  _eq: [uuid!]
+  _gt: [uuid!]
+  _gte: [uuid!]
+  _in: [[uuid!]!]
+  _is_null: Boolean
+  _lt: [uuid!]
+  _lte: [uuid!]
+  _neq: [uuid!]
+  _nin: [[uuid!]!]
+}
 
 """
 Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'.

--- a/libs/gql/admin/api/src/generated/schema.json
+++ b/libs/gql/admin/api/src/generated/schema.json
@@ -8147,7 +8147,7 @@
         "fields": [
           {
             "name": "dateEnd",
-            "description": "The end date including time on the UTC timezone.",
+            "description": "The end date including time.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8163,7 +8163,7 @@
           },
           {
             "name": "dateStart",
-            "description": "The start date including time on the UTC timezone.",
+            "description": "The start date including time.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26183,6 +26183,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "clr7j9mmt0q2j01uo9zrs2fm7",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PackCreateManyInlineInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createdAt",
             "description": null,
             "type": {
@@ -29157,6 +29169,18 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "clr7j9mmt0q2j01uo9zrs2fm7",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PackUpdateManyInlineInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "description",
             "description": "description input for default locale (en)",
@@ -33103,6 +33127,51 @@
             "deprecationReason": null
           },
           {
+            "name": "organizer",
+            "description": null,
+            "args": [
+              {
+                "name": "forceParentLocale",
+                "description": "Sets the locale of the parent document as the first locale in the fallback locales in the query's subtree.\n\nNote that `organizer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.\nThe first locale matching the provided list will be returned, localized entries that do not have the provided locale defined will be filtered out.\n\nThis argument will affect any existing locale filtering defined in the query's tree for the subtree.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locales",
+                "description": "Allows to optionally override locale filtering behaviour in the query's subtree.\n\nNote that `organizer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.\nThe first locale matching the provided list will be returned, localized entries that do not have the provided locale defined will be filtered out.\n\nThis argument will overwrite any existing locale filtering defined in the query's tree for the subtree.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Locale",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Organizer",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "publishedAt",
             "description": "The time the document was published. Null on documents in draft stage.",
             "args": [
@@ -33639,6 +33708,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizer",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "OrganizerCreateOneInlineInput",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -34938,6 +35019,18 @@
             "deprecationReason": null
           },
           {
+            "name": "organizer",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "OrganizerWhereInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "publishedAt",
             "description": null,
             "type": {
@@ -35401,6 +35494,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizer",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "OrganizerUpdateOneInlineInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -37113,6 +37218,18 @@
             "deprecationReason": null
           },
           {
+            "name": "organizer",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "OrganizerWhereInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "publishedAt",
             "description": null,
             "type": {
@@ -37601,7 +37718,7 @@
           },
           {
             "name": "eventDateLocation",
-            "description": "Define the location and date for this option.\nImportant ! It will determine the release and availability for the Pass access.",
+            "description": "Define the location and date for this option.",
             "args": [
               {
                 "name": "forceParentLocale",
@@ -67524,6 +67641,64 @@
             "deprecationReason": null
           },
           {
+            "name": "delete_packNftSupply",
+            "description": "delete data from the table: \"packNftSupply\"",
+            "args": [
+              {
+                "name": "where",
+                "description": "filter the rows which have to be deleted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "packNftSupply_bool_exp",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftSupply_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "delete_packNftSupply_by_pk",
+            "description": "delete single row from the table: \"packNftSupply\"",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "uuid",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftSupply",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "delete_packOrderSums",
             "description": "delete data from the table: \"packOrderSums\"",
             "args": [
@@ -69509,6 +69684,96 @@
             "type": {
               "kind": "OBJECT",
               "name": "packNftContract",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "insert_packNftSupply",
+            "description": "insert data into the table: \"packNftSupply\"",
+            "args": [
+              {
+                "name": "objects",
+                "description": "the rows to be inserted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "packNftSupply_insert_input",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "on_conflict",
+                "description": "upsert condition",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftSupply_on_conflict",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftSupply_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "insert_packNftSupply_one",
+            "description": "insert a single row into the table: \"packNftSupply\"",
+            "args": [
+              {
+                "name": "object",
+                "description": "the row to be inserted",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "packNftSupply_insert_input",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "on_conflict",
+                "description": "upsert condition",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftSupply_on_conflict",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftSupply",
               "ofType": null
             },
             "isDeprecated": false,
@@ -79471,6 +79736,129 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "packNftContract_mutation_response",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_packNftSupply",
+            "description": "update data of the table: \"packNftSupply\"",
+            "args": [
+              {
+                "name": "_set",
+                "description": "sets the columns of the filtered rows to the given values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftSupply_set_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows which have to be updated",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "packNftSupply_bool_exp",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftSupply_mutation_response",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_packNftSupply_by_pk",
+            "description": "update single row of the table: \"packNftSupply\"",
+            "args": [
+              {
+                "name": "_set",
+                "description": "sets the columns of the filtered rows to the given values",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftSupply_set_input",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pk_columns",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "packNftSupply_pk_columns_input",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftSupply",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_packNftSupply_many",
+            "description": "update multiples rows of table: \"packNftSupply\"",
+            "args": [
+              {
+                "name": "updates",
+                "description": "updates to execute, in order",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "INPUT_OBJECT",
+                        "name": "packNftSupply_updates",
+                        "ofType": null
+                      }
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "packNftSupply_mutation_response",
                 "ofType": null
               }
             },
@@ -90789,6 +91177,2069 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftSupply",
+        "description": "This table represents the supply details of pack NFTs, tracking the ownership, contents, and metadata associated with each pack.",
+        "fields": [
+          {
+            "name": "chainId",
+            "description": "The specific blockchain or network on which the pack NFT exists.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": "The address of the smart contract representing the pack NFT. Essential for blockchain interactions.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentOwnerAddress",
+            "description": "The blockchain address of the current owner of the pack NFT.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "Any error messages related to this pack NFT, particularly during transactions or metadata retrieval.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts",
+            "description": "An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "uuid",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastNftTransferId",
+            "description": "The reference to the latest transfer record for this pack NFT.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": "The identifier of the organizer associated with this pack NFT.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": "A unique identifier for the pack within the platform.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "redeemableNfts",
+            "description": "An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tokenUri",
+            "description": "The URI pointing to the metadata of the pack NFT.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "timestamptz",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftSupply_aggregate",
+        "description": "aggregated selection of \"packNftSupply\"",
+        "fields": [
+          {
+            "name": "aggregate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftSupply_aggregate_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nodes",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "packNftSupply",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftSupply_aggregate_fields",
+        "description": "aggregate fields of \"packNftSupply\"",
+        "fields": [
+          {
+            "name": "count",
+            "description": null,
+            "args": [
+              {
+                "name": "columns",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "packNftSupply_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "distinct",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "max",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftSupply_max_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "min",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftSupply_min_fields",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftSupply_bool_exp",
+        "description": "Boolean expression to filter rows from the table \"packNftSupply\". All fields are combined with a logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_and",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftSupply_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_not",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftSupply_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_or",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftSupply_bool_exp",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "chainId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentOwnerAddress",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "uuid_array_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "uuid_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastNftTransferId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "uuid_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "redeemableNfts",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "uuid_array_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tokenUri",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "String_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "timestamptz_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "packNftSupply_constraint",
+        "description": "unique or primary key constraints on table \"packNftSupply\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "packNftSupply_contractAddress_chainId_packId_key",
+            "description": "unique or primary key constraint on columns \"chainId\", \"contractAddress\", \"packId\"",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftSupply_pkey",
+            "description": "unique or primary key constraint on columns \"id\"",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftSupply_insert_input",
+        "description": "input type for inserting data into table \"packNftSupply\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "chainId",
+            "description": "The specific blockchain or network on which the pack NFT exists.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": "The address of the smart contract representing the pack NFT. Essential for blockchain interactions.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentOwnerAddress",
+            "description": "The blockchain address of the current owner of the pack NFT.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "Any error messages related to this pack NFT, particularly during transactions or metadata retrieval.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts",
+            "description": "An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastNftTransferId",
+            "description": "The reference to the latest transfer record for this pack NFT.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": "The identifier of the organizer associated with this pack NFT.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": "A unique identifier for the pack within the platform.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "redeemableNfts",
+            "description": "An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tokenUri",
+            "description": "The URI pointing to the metadata of the pack NFT.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftSupply_max_fields",
+        "description": "aggregate max on columns",
+        "fields": [
+          {
+            "name": "chainId",
+            "description": "The specific blockchain or network on which the pack NFT exists.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": "The address of the smart contract representing the pack NFT. Essential for blockchain interactions.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentOwnerAddress",
+            "description": "The blockchain address of the current owner of the pack NFT.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "Any error messages related to this pack NFT, particularly during transactions or metadata retrieval.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts",
+            "description": "An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastNftTransferId",
+            "description": "The reference to the latest transfer record for this pack NFT.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": "The identifier of the organizer associated with this pack NFT.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": "A unique identifier for the pack within the platform.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "redeemableNfts",
+            "description": "An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tokenUri",
+            "description": "The URI pointing to the metadata of the pack NFT.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftSupply_min_fields",
+        "description": "aggregate min on columns",
+        "fields": [
+          {
+            "name": "chainId",
+            "description": "The specific blockchain or network on which the pack NFT exists.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": "The address of the smart contract representing the pack NFT. Essential for blockchain interactions.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentOwnerAddress",
+            "description": "The blockchain address of the current owner of the pack NFT.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "Any error messages related to this pack NFT, particularly during transactions or metadata retrieval.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts",
+            "description": "An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastNftTransferId",
+            "description": "The reference to the latest transfer record for this pack NFT.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": "The identifier of the organizer associated with this pack NFT.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": "A unique identifier for the pack within the platform.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "redeemableNfts",
+            "description": "An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened.",
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tokenUri",
+            "description": "The URI pointing to the metadata of the pack NFT.",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "packNftSupply_mutation_response",
+        "description": "response of any mutation on the table \"packNftSupply\"",
+        "fields": [
+          {
+            "name": "affected_rows",
+            "description": "number of rows affected by the mutation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "returning",
+            "description": "data from the rows affected by the mutation",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "packNftSupply",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftSupply_on_conflict",
+        "description": "on_conflict condition type for table \"packNftSupply\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "constraint",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "packNftSupply_constraint",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "update_columns",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "packNftSupply_update_column",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": "[]",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftSupply_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftSupply_order_by",
+        "description": "Ordering options when selecting data from \"packNftSupply\".",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "chainId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentOwnerAddress",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastNftTransferId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "redeemableNfts",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tokenUri",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftSupply_pk_columns_input",
+        "description": "primary key columns input for table: packNftSupply",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "uuid",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "packNftSupply_select_column",
+        "description": "select columns of table \"packNftSupply\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "chainId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentOwnerAddress",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastNftTransferId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "redeemableNfts",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tokenUri",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftSupply_set_input",
+        "description": "input type for updating data in table \"packNftSupply\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "chainId",
+            "description": "The specific blockchain or network on which the pack NFT exists.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": "The address of the smart contract representing the pack NFT. Essential for blockchain interactions.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentOwnerAddress",
+            "description": "The blockchain address of the current owner of the pack NFT.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "Any error messages related to this pack NFT, particularly during transactions or metadata retrieval.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts",
+            "description": "An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastNftTransferId",
+            "description": "The reference to the latest transfer record for this pack NFT.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": "The identifier of the organizer associated with this pack NFT.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": "A unique identifier for the pack within the platform.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "redeemableNfts",
+            "description": "An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tokenUri",
+            "description": "The URI pointing to the metadata of the pack NFT.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftSupply_stream_cursor_input",
+        "description": "Streaming cursor of the table \"packNftSupply\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "initial_value",
+            "description": "Stream column input with initial value",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "packNftSupply_stream_cursor_value_input",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ordering",
+            "description": "cursor ordering",
+            "type": {
+              "kind": "ENUM",
+              "name": "cursor_ordering",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftSupply_stream_cursor_value_input",
+        "description": "Initial value of the column from where the streaming should start",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "chainId",
+            "description": "The specific blockchain or network on which the pack NFT exists.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": "The address of the smart contract representing the pack NFT. Essential for blockchain interactions.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentOwnerAddress",
+            "description": "The blockchain address of the current owner of the pack NFT.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "Any error messages related to this pack NFT, particularly during transactions or metadata retrieval.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts",
+            "description": "An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastNftTransferId",
+            "description": "The reference to the latest transfer record for this pack NFT.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "uuid",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": "The identifier of the organizer associated with this pack NFT.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": "A unique identifier for the pack within the platform.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "redeemableNfts",
+            "description": "An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened.",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tokenUri",
+            "description": "The URI pointing to the metadata of the pack NFT.",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "timestamptz",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "packNftSupply_update_column",
+        "description": "update columns of table \"packNftSupply\"",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "chainId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contractAddress",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "currentOwnerAddress",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "error",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eventPassNfts",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastNftTransferId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizerId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packId",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "redeemableNfts",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tokenUri",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updated_at",
+            "description": "column name",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "packNftSupply_updates",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_set",
+            "description": "sets the columns of the filtered rows to the given values",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "packNftSupply_set_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "where",
+            "description": "filter the rows which have to be updated",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "packNftSupply_bool_exp",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -103159,6 +105610,229 @@
             "type": {
               "kind": "OBJECT",
               "name": "packNftContract",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftSupply",
+            "description": "fetch data from the table: \"packNftSupply\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "packNftSupply_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "packNftSupply_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftSupply_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "packNftSupply",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftSupply_aggregate",
+            "description": "fetch aggregated fields from the table: \"packNftSupply\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "packNftSupply_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "packNftSupply_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftSupply_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "packNftSupply_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftSupply_by_pk",
+            "description": "fetch data from the table: \"packNftSupply\" using primary key columns",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "uuid",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftSupply",
               "ofType": null
             },
             "isDeprecated": false,
@@ -116881,6 +119555,302 @@
             "deprecationReason": null
           },
           {
+            "name": "packNftSupply",
+            "description": "fetch data from the table: \"packNftSupply\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "packNftSupply_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "packNftSupply_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftSupply_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "packNftSupply",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftSupply_aggregate",
+            "description": "fetch aggregated fields from the table: \"packNftSupply\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "packNftSupply_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "packNftSupply_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftSupply_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "packNftSupply_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftSupply_by_pk",
+            "description": "fetch data from the table: \"packNftSupply\" using primary key columns",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "uuid",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "packNftSupply",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "packNftSupply_stream",
+            "description": "fetch data from the table in a streaming manner: \"packNftSupply\"",
+            "args": [
+              {
+                "name": "batch_size",
+                "description": "maximum number of rows returned in a single batch",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "cursor",
+                "description": "cursor to stream the results returned by the query",
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "packNftSupply_stream_cursor_input",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "packNftSupply_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "packNftSupply",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "packOrderSums",
             "description": "fetch data from the table: \"packOrderSums\"",
             "args": [
@@ -120754,6 +123724,245 @@
         "description": null,
         "fields": null,
         "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "uuid_array_comparison_exp",
+        "description": "Boolean expression to compare columns of type \"uuid\". All fields are combined with logical 'AND'.",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_contained_in",
+            "description": "is the array contained in the given array value",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_contains",
+            "description": "does the array contain the given value",
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_eq",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gt",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_gte",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "uuid",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_is_null",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lt",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_lte",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_neq",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "uuid",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_nin",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "uuid",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "interfaces": null,
         "enumValues": null,
         "possibleTypes": null

--- a/libs/gql/admin/api/src/queries/organizer/event/pass/eventPassNft.query.gql
+++ b/libs/gql/admin/api/src/queries/organizer/event/pass/eventPassNft.query.gql
@@ -23,3 +23,18 @@ query GetListCurrentOwnerAddressForContractAddress($contractAddress: String) {
     tokenId
   }
 }
+
+query GetCurrentOwnerAddressByContractAndTokenId(
+  $contractAddress: String!
+  $tokenId: bigint!
+) {
+  eventPassNft(
+    where: {
+      contractAddress: { _eq: $contractAddress }
+      tokenId: { _eq: $tokenId }
+    }
+  ) {
+    id
+    currentOwnerAddress
+  }
+}

--- a/libs/gql/admin/api/src/queries/organizer/event/pass/packNftSupply.mutation.gql
+++ b/libs/gql/admin/api/src/queries/organizer/event/pass/packNftSupply.mutation.gql
@@ -1,0 +1,16 @@
+mutation UpdatePackNftSupplyMany($updates: [packNftSupply_updates!]!) {
+  update_packNftSupply_many(updates: $updates) {
+    affected_rows
+    returning {
+      id
+      contractAddress
+      currentOwnerAddress
+    }
+  }
+}
+
+mutation CreatePackNftSupply($objects: [packNftSupply_insert_input!]!) {
+  insert_packNftSupply(objects: $objects) {
+    affected_rows
+  }
+}

--- a/libs/gql/admin/api/src/queries/organizer/event/pass/packNftSupply.query.gql
+++ b/libs/gql/admin/api/src/queries/organizer/event/pass/packNftSupply.query.gql
@@ -1,0 +1,16 @@
+query GetPackNftSupplyWithNullNftsFromCurrentOwnerAddress(
+  $contractAddress: String!
+  $currentOwnerAddress: String!
+) {
+  packNftSupply(
+    where: {
+      redeemableNfts: { _is_null: true }
+      eventPassNfts: { _is_null: true }
+      contractAddress: { _eq: $contractAddress }
+      currentOwnerAddress: { _eq: $currentOwnerAddress }
+    }
+  ) {
+    id
+    organizerId
+  }
+}

--- a/libs/gql/admin/types/src/generated/index.ts
+++ b/libs/gql/admin/types/src/generated/index.ts
@@ -268,6 +268,14 @@ export type GetListCurrentOwnerAddressForContractAddressQueryVariables = Types.E
 
 export type GetListCurrentOwnerAddressForContractAddressQuery = { __typename?: 'query_root', eventPassNft: Array<{ __typename?: 'eventPassNft', currentOwnerAddress?: string | null, tokenId: any }> };
 
+export type GetCurrentOwnerAddressByContractAndTokenIdQueryVariables = Types.Exact<{
+  contractAddress: Types.Scalars['String'];
+  tokenId: Types.Scalars['bigint'];
+}>;
+
+
+export type GetCurrentOwnerAddressByContractAndTokenIdQuery = { __typename?: 'query_root', eventPassNft: Array<{ __typename?: 'eventPassNft', id: any, currentOwnerAddress?: string | null }> };
+
 export type CreateEventPassNftContractMutationVariables = Types.Exact<{
   object: Types.EventPassNftContract_Insert_Input;
 }>;

--- a/libs/gql/admin/types/src/generated/index.ts
+++ b/libs/gql/admin/types/src/generated/index.ts
@@ -331,6 +331,28 @@ export type GetPackNftContractFromPackIdQueryVariables = Types.Exact<{
 
 export type GetPackNftContractFromPackIdQuery = { __typename?: 'query_root', packNftContract: Array<{ __typename?: 'packNftContract', id: any, chainId: string, rewardsPerPack: number, organizerId: string, contractAddress: string, eventPassIds: any, eventPassNfts: Array<{ __typename?: 'eventPassNft', tokenId: any, contractAddress: string, currentOwnerAddress?: string | null, eventPassId: string, packId?: string | null }> }> };
 
+export type UpdatePackNftSupplyManyMutationVariables = Types.Exact<{
+  updates: Array<Types.PackNftSupply_Updates> | Types.PackNftSupply_Updates;
+}>;
+
+
+export type UpdatePackNftSupplyManyMutation = { __typename?: 'mutation_root', update_packNftSupply_many?: Array<{ __typename?: 'packNftSupply_mutation_response', affected_rows: number, returning: Array<{ __typename?: 'packNftSupply', id: any, contractAddress: string, currentOwnerAddress?: string | null }> } | null> | null };
+
+export type CreatePackNftSupplyMutationVariables = Types.Exact<{
+  objects: Array<Types.PackNftSupply_Insert_Input> | Types.PackNftSupply_Insert_Input;
+}>;
+
+
+export type CreatePackNftSupplyMutation = { __typename?: 'mutation_root', insert_packNftSupply?: { __typename?: 'packNftSupply_mutation_response', affected_rows: number } | null };
+
+export type GetPackNftSupplyWithNullNftsFromCurrentOwnerAddressQueryVariables = Types.Exact<{
+  contractAddress: Types.Scalars['String'];
+  currentOwnerAddress: Types.Scalars['String'];
+}>;
+
+
+export type GetPackNftSupplyWithNullNftsFromCurrentOwnerAddressQuery = { __typename?: 'query_root', packNftSupply: Array<{ __typename?: 'packNftSupply', id: any, organizerId: string }> };
+
 export type CreatePassAmountMutationVariables = Types.Exact<{
   passAmount: Types.PassAmount_Insert_Input;
 }>;

--- a/libs/gql/anonymous/api/src/generated/schema.graphql
+++ b/libs/gql/anonymous/api/src/generated/schema.graphql
@@ -1635,10 +1635,10 @@ input EventCreateOneInlineInput {
 Model used to define the different locations and dates of an event. A festival or a tournament for instance could have several.
 """
 type EventDateLocation implements Entity {
-  """The end date including time on the UTC timezone."""
+  """The end date including time."""
   dateEnd: DateTime!
 
-  """The start date including time on the UTC timezone."""
+  """The start date including time."""
   dateStart: DateTime!
 
   """The unique identifier"""
@@ -5306,6 +5306,7 @@ type OrganizerConnection {
 }
 
 input OrganizerCreateInput {
+  clr7j9mmt0q2j01uo9zrs2fm7: PackCreateManyInlineInput
   createdAt: DateTime
 
   """description input for default locale (en)"""
@@ -5855,6 +5856,8 @@ enum OrganizerOrderByInput {
 }
 
 input OrganizerUpdateInput {
+  clr7j9mmt0q2j01uo9zrs2fm7: PackUpdateManyInlineInput
+
   """description input for default locale (en)"""
   description: RichTextAST
   discordWidgetId: String
@@ -6635,6 +6638,27 @@ type Pack implements Entity & Node {
   Permanent name associated with the NFT. Cannot be changed or localized.
   """
   nftName: String!
+  organizer(
+    """
+    Sets the locale of the parent document as the first locale in the fallback locales in the query's subtree.
+    
+    Note that `organizer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, localized entries that do not have the provided locale defined will be filtered out.
+    
+    This argument will affect any existing locale filtering defined in the query's tree for the subtree.
+    """
+    forceParentLocale: Boolean
+
+    """
+    Allows to optionally override locale filtering behaviour in the query's subtree.
+    
+    Note that `organizer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, localized entries that do not have the provided locale defined will be filtered out.
+    
+    This argument will overwrite any existing locale filtering defined in the query's tree for the subtree.
+    """
+    locales: [Locale!]
+  ): Organizer
 
   """The time the document was published. Null on documents in draft stage."""
   publishedAt(
@@ -6768,6 +6792,7 @@ input PackCreateInput {
   nftDescription: String!
   nftImage: AssetCreateOneInlineInput!
   nftName: String!
+  organizer: OrganizerCreateOneInlineInput
   updatedAt: DateTime
 }
 
@@ -7005,6 +7030,7 @@ input PackManyWhereInput {
 
   """All values starting with the given string."""
   nftName_starts_with: String
+  organizer: OrganizerWhereInput
   publishedAt: DateTime
 
   """All values greater than the given value."""
@@ -7088,6 +7114,7 @@ input PackUpdateInput {
   nftDescription: String
   nftImage: AssetUpdateOneInlineInput
   nftName: String
+  organizer: OrganizerUpdateOneInlineInput
 }
 
 input PackUpdateLocalizationDataInput {
@@ -7413,6 +7440,7 @@ input PackWhereInput {
 
   """All values starting with the given string."""
   nftName_starts_with: String
+  organizer: OrganizerWhereInput
   publishedAt: DateTime
 
   """All values greater than the given value."""
@@ -7518,10 +7546,7 @@ type PassOption implements Entity {
   """
   description: String
 
-  """
-  Define the location and date for this option.
-  Important ! It will determine the release and availability for the Pass access.
-  """
+  """Define the location and date for this option."""
   eventDateLocation(
     """
     Sets the locale of the resolved parent document as the only locale in the query's subtree.

--- a/libs/gql/anonymous/api/src/generated/schema.json
+++ b/libs/gql/anonymous/api/src/generated/schema.json
@@ -8135,7 +8135,7 @@
         "fields": [
           {
             "name": "dateEnd",
-            "description": "The end date including time on the UTC timezone.",
+            "description": "The end date including time.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8151,7 +8151,7 @@
           },
           {
             "name": "dateStart",
-            "description": "The start date including time on the UTC timezone.",
+            "description": "The start date including time.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26136,6 +26136,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "clr7j9mmt0q2j01uo9zrs2fm7",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PackCreateManyInlineInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createdAt",
             "description": null,
             "type": {
@@ -29110,6 +29122,18 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "clr7j9mmt0q2j01uo9zrs2fm7",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PackUpdateManyInlineInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "description",
             "description": "description input for default locale (en)",
@@ -32986,6 +33010,51 @@
             "deprecationReason": null
           },
           {
+            "name": "organizer",
+            "description": null,
+            "args": [
+              {
+                "name": "forceParentLocale",
+                "description": "Sets the locale of the parent document as the first locale in the fallback locales in the query's subtree.\n\nNote that `organizer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.\nThe first locale matching the provided list will be returned, localized entries that do not have the provided locale defined will be filtered out.\n\nThis argument will affect any existing locale filtering defined in the query's tree for the subtree.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locales",
+                "description": "Allows to optionally override locale filtering behaviour in the query's subtree.\n\nNote that `organizer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.\nThe first locale matching the provided list will be returned, localized entries that do not have the provided locale defined will be filtered out.\n\nThis argument will overwrite any existing locale filtering defined in the query's tree for the subtree.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Locale",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Organizer",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "publishedAt",
             "description": "The time the document was published. Null on documents in draft stage.",
             "args": [
@@ -33522,6 +33591,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizer",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "OrganizerCreateOneInlineInput",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -34821,6 +34902,18 @@
             "deprecationReason": null
           },
           {
+            "name": "organizer",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "OrganizerWhereInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "publishedAt",
             "description": null,
             "type": {
@@ -35284,6 +35377,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizer",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "OrganizerUpdateOneInlineInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -36996,6 +37101,18 @@
             "deprecationReason": null
           },
           {
+            "name": "organizer",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "OrganizerWhereInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "publishedAt",
             "description": null,
             "type": {
@@ -37484,7 +37601,7 @@
           },
           {
             "name": "eventDateLocation",
-            "description": "Define the location and date for this option.\nImportant ! It will determine the release and availability for the Pass access.",
+            "description": "Define the location and date for this option.",
             "args": [
               {
                 "name": "forceParentLocale",

--- a/libs/gql/shared/types/src/generated/index.ts
+++ b/libs/gql/shared/types/src/generated/index.ts
@@ -1164,9 +1164,9 @@ export type EventCreateOneInlineInput = {
 /** Model used to define the different locations and dates of an event. A festival or a tournament for instance could have several. */
 export type EventDateLocation = Entity & {
   __typename?: 'EventDateLocation';
-  /** The end date including time on the UTC timezone. */
+  /** The end date including time. */
   dateEnd: Scalars['DateTime'];
-  /** The start date including time on the UTC timezone. */
+  /** The start date including time. */
   dateStart: Scalars['DateTime'];
   /** The unique identifier */
   id: Scalars['ID'];
@@ -3747,6 +3747,7 @@ export type OrganizerConnection = {
 };
 
 export type OrganizerCreateInput = {
+  clr7j9mmt0q2j01uo9zrs2fm7?: InputMaybe<PackCreateManyInlineInput>;
   createdAt?: InputMaybe<Scalars['DateTime']>;
   /** description input for default locale (en) */
   description?: InputMaybe<Scalars['RichTextAST']>;
@@ -4166,6 +4167,7 @@ export const enum OrganizerOrderByInput {
 };
 
 export type OrganizerUpdateInput = {
+  clr7j9mmt0q2j01uo9zrs2fm7?: InputMaybe<PackUpdateManyInlineInput>;
   /** description input for default locale (en) */
   description?: InputMaybe<Scalars['RichTextAST']>;
   discordWidgetId?: InputMaybe<Scalars['String']>;
@@ -4670,6 +4672,7 @@ export type Pack = Entity & Node & {
   nftImage: Asset;
   /** Permanent name associated with the NFT. Cannot be changed or localized. */
   nftName: Scalars['String'];
+  organizer?: Maybe<Organizer>;
   /** The time the document was published. Null on documents in draft stage. */
   publishedAt?: Maybe<Scalars['DateTime']>;
   /** User that last published this document */
@@ -4764,6 +4767,16 @@ export type PackNftImageArgs = {
  * The 'Pack' model represents a collection of unique NFTs (eventPasses) bundled together. It serves as a loot system for users, offering them a chance to receive one or more NFTs related to specific events. Each pack contains details about its contents and the associated event, fostering a more engaging and rewarding experience for users.
  *
  */
+export type PackOrganizerArgs = {
+  forceParentLocale?: InputMaybe<Scalars['Boolean']>;
+  locales?: InputMaybe<Array<Locale>>;
+};
+
+
+/**
+ * The 'Pack' model represents a collection of unique NFTs (eventPasses) bundled together. It serves as a loot system for users, offering them a chance to receive one or more NFTs related to specific events. Each pack contains details about its contents and the associated event, fostering a more engaging and rewarding experience for users.
+ *
+ */
 export type PackPublishedAtArgs = {
   variation?: SystemDateTimeFieldVariation;
 };
@@ -4842,6 +4855,7 @@ export type PackCreateInput = {
   nftDescription: Scalars['String'];
   nftImage: AssetCreateOneInlineInput;
   nftName: Scalars['String'];
+  organizer?: InputMaybe<OrganizerCreateOneInlineInput>;
   updatedAt?: InputMaybe<Scalars['DateTime']>;
 };
 
@@ -5027,6 +5041,7 @@ export type PackManyWhereInput = {
   nftName_not_starts_with?: InputMaybe<Scalars['String']>;
   /** All values starting with the given string. */
   nftName_starts_with?: InputMaybe<Scalars['String']>;
+  organizer?: InputMaybe<OrganizerWhereInput>;
   publishedAt?: InputMaybe<Scalars['DateTime']>;
   /** All values greater than the given value. */
   publishedAt_gt?: InputMaybe<Scalars['DateTime']>;
@@ -5094,6 +5109,7 @@ export type PackUpdateInput = {
   nftDescription?: InputMaybe<Scalars['String']>;
   nftImage?: InputMaybe<AssetUpdateOneInlineInput>;
   nftName?: InputMaybe<Scalars['String']>;
+  organizer?: InputMaybe<OrganizerUpdateOneInlineInput>;
 };
 
 export type PackUpdateLocalizationDataInput = {
@@ -5336,6 +5352,7 @@ export type PackWhereInput = {
   nftName_not_starts_with?: InputMaybe<Scalars['String']>;
   /** All values starting with the given string. */
   nftName_starts_with?: InputMaybe<Scalars['String']>;
+  organizer?: InputMaybe<OrganizerWhereInput>;
   publishedAt?: InputMaybe<Scalars['DateTime']>;
   /** All values greater than the given value. */
   publishedAt_gt?: InputMaybe<Scalars['DateTime']>;
@@ -5412,10 +5429,7 @@ export type PassOption = Entity & {
   __typename?: 'PassOption';
   /** Description of the option, like "Access to the event on Day 1" */
   description?: Maybe<Scalars['String']>;
-  /**
-   * Define the location and date for this option.
-   * Important ! It will determine the release and availability for the Pass access.
-   */
+  /** Define the location and date for this option. */
   eventDateLocation?: Maybe<EventDateLocation>;
   /** The unique identifier */
   id: Scalars['ID'];
@@ -9894,6 +9908,10 @@ export type Mutation_Root = {
   delete_packNftContract?: Maybe<PackNftContract_Mutation_Response>;
   /** delete single row from the table: "packNftContract" */
   delete_packNftContract_by_pk?: Maybe<PackNftContract>;
+  /** delete data from the table: "packNftSupply" */
+  delete_packNftSupply?: Maybe<PackNftSupply_Mutation_Response>;
+  /** delete single row from the table: "packNftSupply" */
+  delete_packNftSupply_by_pk?: Maybe<PackNftSupply>;
   /** delete data from the table: "packOrderSums" */
   delete_packOrderSums?: Maybe<PackOrderSums_Mutation_Response>;
   /** delete single row from the table: "packOrderSums" */
@@ -9996,6 +10014,10 @@ export type Mutation_Root = {
   insert_packNftContract?: Maybe<PackNftContract_Mutation_Response>;
   /** insert a single row into the table: "packNftContract" */
   insert_packNftContract_one?: Maybe<PackNftContract>;
+  /** insert data into the table: "packNftSupply" */
+  insert_packNftSupply?: Maybe<PackNftSupply_Mutation_Response>;
+  /** insert a single row into the table: "packNftSupply" */
+  insert_packNftSupply_one?: Maybe<PackNftSupply>;
   /** insert data into the table: "packOrderSums" */
   insert_packOrderSums?: Maybe<PackOrderSums_Mutation_Response>;
   /** insert a single row into the table: "packOrderSums" */
@@ -10266,6 +10288,12 @@ export type Mutation_Root = {
   update_packNftContract_by_pk?: Maybe<PackNftContract>;
   /** update multiples rows of table: "packNftContract" */
   update_packNftContract_many?: Maybe<Array<Maybe<PackNftContract_Mutation_Response>>>;
+  /** update data of the table: "packNftSupply" */
+  update_packNftSupply?: Maybe<PackNftSupply_Mutation_Response>;
+  /** update single row of the table: "packNftSupply" */
+  update_packNftSupply_by_pk?: Maybe<PackNftSupply>;
+  /** update multiples rows of table: "packNftSupply" */
+  update_packNftSupply_many?: Maybe<Array<Maybe<PackNftSupply_Mutation_Response>>>;
   /** update data of the table: "packOrderSums" */
   update_packOrderSums?: Maybe<PackOrderSums_Mutation_Response>;
   /** update single row of the table: "packOrderSums" */
@@ -10725,6 +10753,18 @@ export type Mutation_RootDelete_PackNftContract_By_PkArgs = {
 
 
 /** mutation root */
+export type Mutation_RootDelete_PackNftSupplyArgs = {
+  where: PackNftSupply_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_PackNftSupply_By_PkArgs = {
+  id: Scalars['uuid'];
+};
+
+
+/** mutation root */
 export type Mutation_RootDelete_PackOrderSumsArgs = {
   where: PackOrderSums_Bool_Exp;
 };
@@ -11059,6 +11099,20 @@ export type Mutation_RootInsert_PackNftContractArgs = {
 export type Mutation_RootInsert_PackNftContract_OneArgs = {
   object: PackNftContract_Insert_Input;
   on_conflict?: InputMaybe<PackNftContract_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_PackNftSupplyArgs = {
+  objects: Array<PackNftSupply_Insert_Input>;
+  on_conflict?: InputMaybe<PackNftSupply_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_PackNftSupply_OneArgs = {
+  object: PackNftSupply_Insert_Input;
+  on_conflict?: InputMaybe<PackNftSupply_On_Conflict>;
 };
 
 
@@ -12264,6 +12318,26 @@ export type Mutation_RootUpdate_PackNftContract_By_PkArgs = {
 /** mutation root */
 export type Mutation_RootUpdate_PackNftContract_ManyArgs = {
   updates: Array<PackNftContract_Updates>;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_PackNftSupplyArgs = {
+  _set?: InputMaybe<PackNftSupply_Set_Input>;
+  where: PackNftSupply_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_PackNftSupply_By_PkArgs = {
+  _set?: InputMaybe<PackNftSupply_Set_Input>;
+  pk_columns: PackNftSupply_Pk_Columns_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_PackNftSupply_ManyArgs = {
+  updates: Array<PackNftSupply_Updates>;
 };
 
 
@@ -14090,6 +14164,334 @@ export type PackNftContract_Variance_Fields = {
   rewardsPerPack?: Maybe<Scalars['Float']>;
 };
 
+/** This table represents the supply details of pack NFTs, tracking the ownership, contents, and metadata associated with each pack. */
+export type PackNftSupply = {
+  __typename?: 'packNftSupply';
+  /** The specific blockchain or network on which the pack NFT exists. */
+  chainId: Scalars['String'];
+  /** The address of the smart contract representing the pack NFT. Essential for blockchain interactions. */
+  contractAddress: Scalars['String'];
+  created_at: Scalars['timestamptz'];
+  /** The blockchain address of the current owner of the pack NFT. */
+  currentOwnerAddress?: Maybe<Scalars['String']>;
+  /** Any error messages related to this pack NFT, particularly during transactions or metadata retrieval. */
+  error?: Maybe<Scalars['String']>;
+  /** An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened. */
+  eventPassNfts?: Maybe<Array<Scalars['uuid']>>;
+  id: Scalars['uuid'];
+  /** The reference to the latest transfer record for this pack NFT. */
+  lastNftTransferId?: Maybe<Scalars['uuid']>;
+  /** The identifier of the organizer associated with this pack NFT. */
+  organizerId: Scalars['String'];
+  /** A unique identifier for the pack within the platform. */
+  packId: Scalars['String'];
+  /** An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened. */
+  redeemableNfts?: Maybe<Array<Scalars['uuid']>>;
+  /** The URI pointing to the metadata of the pack NFT. */
+  tokenUri?: Maybe<Scalars['String']>;
+  updated_at: Scalars['timestamptz'];
+};
+
+/** aggregated selection of "packNftSupply" */
+export type PackNftSupply_Aggregate = {
+  __typename?: 'packNftSupply_aggregate';
+  aggregate?: Maybe<PackNftSupply_Aggregate_Fields>;
+  nodes: Array<PackNftSupply>;
+};
+
+/** aggregate fields of "packNftSupply" */
+export type PackNftSupply_Aggregate_Fields = {
+  __typename?: 'packNftSupply_aggregate_fields';
+  count: Scalars['Int'];
+  max?: Maybe<PackNftSupply_Max_Fields>;
+  min?: Maybe<PackNftSupply_Min_Fields>;
+};
+
+
+/** aggregate fields of "packNftSupply" */
+export type PackNftSupply_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<PackNftSupply_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']>;
+};
+
+/** Boolean expression to filter rows from the table "packNftSupply". All fields are combined with a logical 'AND'. */
+export type PackNftSupply_Bool_Exp = {
+  _and?: InputMaybe<Array<PackNftSupply_Bool_Exp>>;
+  _not?: InputMaybe<PackNftSupply_Bool_Exp>;
+  _or?: InputMaybe<Array<PackNftSupply_Bool_Exp>>;
+  chainId?: InputMaybe<String_Comparison_Exp>;
+  contractAddress?: InputMaybe<String_Comparison_Exp>;
+  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  currentOwnerAddress?: InputMaybe<String_Comparison_Exp>;
+  error?: InputMaybe<String_Comparison_Exp>;
+  eventPassNfts?: InputMaybe<Uuid_Array_Comparison_Exp>;
+  id?: InputMaybe<Uuid_Comparison_Exp>;
+  lastNftTransferId?: InputMaybe<Uuid_Comparison_Exp>;
+  organizerId?: InputMaybe<String_Comparison_Exp>;
+  packId?: InputMaybe<String_Comparison_Exp>;
+  redeemableNfts?: InputMaybe<Uuid_Array_Comparison_Exp>;
+  tokenUri?: InputMaybe<String_Comparison_Exp>;
+  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "packNftSupply" */
+export const enum PackNftSupply_Constraint {
+  /** unique or primary key constraint on columns "chainId", "contractAddress", "packId" */
+  PackNftSupplyContractAddressChainIdPackIdKey = 'packNftSupply_contractAddress_chainId_packId_key',
+  /** unique or primary key constraint on columns "id" */
+  PackNftSupplyPkey = 'packNftSupply_pkey'
+};
+
+/** input type for inserting data into table "packNftSupply" */
+export type PackNftSupply_Insert_Input = {
+  /** The specific blockchain or network on which the pack NFT exists. */
+  chainId?: InputMaybe<Scalars['String']>;
+  /** The address of the smart contract representing the pack NFT. Essential for blockchain interactions. */
+  contractAddress?: InputMaybe<Scalars['String']>;
+  created_at?: InputMaybe<Scalars['timestamptz']>;
+  /** The blockchain address of the current owner of the pack NFT. */
+  currentOwnerAddress?: InputMaybe<Scalars['String']>;
+  /** Any error messages related to this pack NFT, particularly during transactions or metadata retrieval. */
+  error?: InputMaybe<Scalars['String']>;
+  /** An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened. */
+  eventPassNfts?: InputMaybe<Array<Scalars['uuid']>>;
+  id?: InputMaybe<Scalars['uuid']>;
+  /** The reference to the latest transfer record for this pack NFT. */
+  lastNftTransferId?: InputMaybe<Scalars['uuid']>;
+  /** The identifier of the organizer associated with this pack NFT. */
+  organizerId?: InputMaybe<Scalars['String']>;
+  /** A unique identifier for the pack within the platform. */
+  packId?: InputMaybe<Scalars['String']>;
+  /** An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened. */
+  redeemableNfts?: InputMaybe<Array<Scalars['uuid']>>;
+  /** The URI pointing to the metadata of the pack NFT. */
+  tokenUri?: InputMaybe<Scalars['String']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']>;
+};
+
+/** aggregate max on columns */
+export type PackNftSupply_Max_Fields = {
+  __typename?: 'packNftSupply_max_fields';
+  /** The specific blockchain or network on which the pack NFT exists. */
+  chainId?: Maybe<Scalars['String']>;
+  /** The address of the smart contract representing the pack NFT. Essential for blockchain interactions. */
+  contractAddress?: Maybe<Scalars['String']>;
+  created_at?: Maybe<Scalars['timestamptz']>;
+  /** The blockchain address of the current owner of the pack NFT. */
+  currentOwnerAddress?: Maybe<Scalars['String']>;
+  /** Any error messages related to this pack NFT, particularly during transactions or metadata retrieval. */
+  error?: Maybe<Scalars['String']>;
+  /** An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened. */
+  eventPassNfts?: Maybe<Array<Scalars['uuid']>>;
+  id?: Maybe<Scalars['uuid']>;
+  /** The reference to the latest transfer record for this pack NFT. */
+  lastNftTransferId?: Maybe<Scalars['uuid']>;
+  /** The identifier of the organizer associated with this pack NFT. */
+  organizerId?: Maybe<Scalars['String']>;
+  /** A unique identifier for the pack within the platform. */
+  packId?: Maybe<Scalars['String']>;
+  /** An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened. */
+  redeemableNfts?: Maybe<Array<Scalars['uuid']>>;
+  /** The URI pointing to the metadata of the pack NFT. */
+  tokenUri?: Maybe<Scalars['String']>;
+  updated_at?: Maybe<Scalars['timestamptz']>;
+};
+
+/** aggregate min on columns */
+export type PackNftSupply_Min_Fields = {
+  __typename?: 'packNftSupply_min_fields';
+  /** The specific blockchain or network on which the pack NFT exists. */
+  chainId?: Maybe<Scalars['String']>;
+  /** The address of the smart contract representing the pack NFT. Essential for blockchain interactions. */
+  contractAddress?: Maybe<Scalars['String']>;
+  created_at?: Maybe<Scalars['timestamptz']>;
+  /** The blockchain address of the current owner of the pack NFT. */
+  currentOwnerAddress?: Maybe<Scalars['String']>;
+  /** Any error messages related to this pack NFT, particularly during transactions or metadata retrieval. */
+  error?: Maybe<Scalars['String']>;
+  /** An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened. */
+  eventPassNfts?: Maybe<Array<Scalars['uuid']>>;
+  id?: Maybe<Scalars['uuid']>;
+  /** The reference to the latest transfer record for this pack NFT. */
+  lastNftTransferId?: Maybe<Scalars['uuid']>;
+  /** The identifier of the organizer associated with this pack NFT. */
+  organizerId?: Maybe<Scalars['String']>;
+  /** A unique identifier for the pack within the platform. */
+  packId?: Maybe<Scalars['String']>;
+  /** An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened. */
+  redeemableNfts?: Maybe<Array<Scalars['uuid']>>;
+  /** The URI pointing to the metadata of the pack NFT. */
+  tokenUri?: Maybe<Scalars['String']>;
+  updated_at?: Maybe<Scalars['timestamptz']>;
+};
+
+/** response of any mutation on the table "packNftSupply" */
+export type PackNftSupply_Mutation_Response = {
+  __typename?: 'packNftSupply_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int'];
+  /** data from the rows affected by the mutation */
+  returning: Array<PackNftSupply>;
+};
+
+/** on_conflict condition type for table "packNftSupply" */
+export type PackNftSupply_On_Conflict = {
+  constraint: PackNftSupply_Constraint;
+  update_columns?: Array<PackNftSupply_Update_Column>;
+  where?: InputMaybe<PackNftSupply_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "packNftSupply". */
+export type PackNftSupply_Order_By = {
+  chainId?: InputMaybe<Order_By>;
+  contractAddress?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  currentOwnerAddress?: InputMaybe<Order_By>;
+  error?: InputMaybe<Order_By>;
+  eventPassNfts?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  lastNftTransferId?: InputMaybe<Order_By>;
+  organizerId?: InputMaybe<Order_By>;
+  packId?: InputMaybe<Order_By>;
+  redeemableNfts?: InputMaybe<Order_By>;
+  tokenUri?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: packNftSupply */
+export type PackNftSupply_Pk_Columns_Input = {
+  id: Scalars['uuid'];
+};
+
+/** select columns of table "packNftSupply" */
+export const enum PackNftSupply_Select_Column {
+  /** column name */
+  ChainId = 'chainId',
+  /** column name */
+  ContractAddress = 'contractAddress',
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  CurrentOwnerAddress = 'currentOwnerAddress',
+  /** column name */
+  Error = 'error',
+  /** column name */
+  EventPassNfts = 'eventPassNfts',
+  /** column name */
+  Id = 'id',
+  /** column name */
+  LastNftTransferId = 'lastNftTransferId',
+  /** column name */
+  OrganizerId = 'organizerId',
+  /** column name */
+  PackId = 'packId',
+  /** column name */
+  RedeemableNfts = 'redeemableNfts',
+  /** column name */
+  TokenUri = 'tokenUri',
+  /** column name */
+  UpdatedAt = 'updated_at'
+};
+
+/** input type for updating data in table "packNftSupply" */
+export type PackNftSupply_Set_Input = {
+  /** The specific blockchain or network on which the pack NFT exists. */
+  chainId?: InputMaybe<Scalars['String']>;
+  /** The address of the smart contract representing the pack NFT. Essential for blockchain interactions. */
+  contractAddress?: InputMaybe<Scalars['String']>;
+  created_at?: InputMaybe<Scalars['timestamptz']>;
+  /** The blockchain address of the current owner of the pack NFT. */
+  currentOwnerAddress?: InputMaybe<Scalars['String']>;
+  /** Any error messages related to this pack NFT, particularly during transactions or metadata retrieval. */
+  error?: InputMaybe<Scalars['String']>;
+  /** An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened. */
+  eventPassNfts?: InputMaybe<Array<Scalars['uuid']>>;
+  id?: InputMaybe<Scalars['uuid']>;
+  /** The reference to the latest transfer record for this pack NFT. */
+  lastNftTransferId?: InputMaybe<Scalars['uuid']>;
+  /** The identifier of the organizer associated with this pack NFT. */
+  organizerId?: InputMaybe<Scalars['String']>;
+  /** A unique identifier for the pack within the platform. */
+  packId?: InputMaybe<Scalars['String']>;
+  /** An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened. */
+  redeemableNfts?: InputMaybe<Array<Scalars['uuid']>>;
+  /** The URI pointing to the metadata of the pack NFT. */
+  tokenUri?: InputMaybe<Scalars['String']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']>;
+};
+
+/** Streaming cursor of the table "packNftSupply" */
+export type PackNftSupply_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: PackNftSupply_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type PackNftSupply_Stream_Cursor_Value_Input = {
+  /** The specific blockchain or network on which the pack NFT exists. */
+  chainId?: InputMaybe<Scalars['String']>;
+  /** The address of the smart contract representing the pack NFT. Essential for blockchain interactions. */
+  contractAddress?: InputMaybe<Scalars['String']>;
+  created_at?: InputMaybe<Scalars['timestamptz']>;
+  /** The blockchain address of the current owner of the pack NFT. */
+  currentOwnerAddress?: InputMaybe<Scalars['String']>;
+  /** Any error messages related to this pack NFT, particularly during transactions or metadata retrieval. */
+  error?: InputMaybe<Scalars['String']>;
+  /** An array of UUIDs representing the event pass NFTs contained in the pack. Null if the pack is unopened. */
+  eventPassNfts?: InputMaybe<Array<Scalars['uuid']>>;
+  id?: InputMaybe<Scalars['uuid']>;
+  /** The reference to the latest transfer record for this pack NFT. */
+  lastNftTransferId?: InputMaybe<Scalars['uuid']>;
+  /** The identifier of the organizer associated with this pack NFT. */
+  organizerId?: InputMaybe<Scalars['String']>;
+  /** A unique identifier for the pack within the platform. */
+  packId?: InputMaybe<Scalars['String']>;
+  /** An array of UUIDs representing redeemable NFTs contained in the pack. Null if the pack is unopened. */
+  redeemableNfts?: InputMaybe<Array<Scalars['uuid']>>;
+  /** The URI pointing to the metadata of the pack NFT. */
+  tokenUri?: InputMaybe<Scalars['String']>;
+  updated_at?: InputMaybe<Scalars['timestamptz']>;
+};
+
+/** update columns of table "packNftSupply" */
+export const enum PackNftSupply_Update_Column {
+  /** column name */
+  ChainId = 'chainId',
+  /** column name */
+  ContractAddress = 'contractAddress',
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  CurrentOwnerAddress = 'currentOwnerAddress',
+  /** column name */
+  Error = 'error',
+  /** column name */
+  EventPassNfts = 'eventPassNfts',
+  /** column name */
+  Id = 'id',
+  /** column name */
+  LastNftTransferId = 'lastNftTransferId',
+  /** column name */
+  OrganizerId = 'organizerId',
+  /** column name */
+  PackId = 'packId',
+  /** column name */
+  RedeemableNfts = 'redeemableNfts',
+  /** column name */
+  TokenUri = 'tokenUri',
+  /** column name */
+  UpdatedAt = 'updated_at'
+};
+
+export type PackNftSupply_Updates = {
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<PackNftSupply_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: PackNftSupply_Bool_Exp;
+};
+
 /** Hold the sums for the Pack Orders */
 export type PackOrderSums = {
   __typename?: 'packOrderSums';
@@ -15291,6 +15693,12 @@ export type Query_Root = {
   packNftContract_aggregate: PackNftContract_Aggregate;
   /** fetch data from the table: "packNftContract" using primary key columns */
   packNftContract_by_pk?: Maybe<PackNftContract>;
+  /** fetch data from the table: "packNftSupply" */
+  packNftSupply: Array<PackNftSupply>;
+  /** fetch aggregated fields from the table: "packNftSupply" */
+  packNftSupply_aggregate: PackNftSupply_Aggregate;
+  /** fetch data from the table: "packNftSupply" using primary key columns */
+  packNftSupply_by_pk?: Maybe<PackNftSupply>;
   /** fetch data from the table: "packOrderSums" */
   packOrderSums: Array<PackOrderSums>;
   /** fetch aggregated fields from the table: "packOrderSums" */
@@ -15950,6 +16358,29 @@ export type Query_RootPackNftContract_AggregateArgs = {
 
 
 export type Query_RootPackNftContract_By_PkArgs = {
+  id: Scalars['uuid'];
+};
+
+
+export type Query_RootPackNftSupplyArgs = {
+  distinct_on?: InputMaybe<Array<PackNftSupply_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<PackNftSupply_Order_By>>;
+  where?: InputMaybe<PackNftSupply_Bool_Exp>;
+};
+
+
+export type Query_RootPackNftSupply_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<PackNftSupply_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<PackNftSupply_Order_By>>;
+  where?: InputMaybe<PackNftSupply_Bool_Exp>;
+};
+
+
+export type Query_RootPackNftSupply_By_PkArgs = {
   id: Scalars['uuid'];
 };
 
@@ -17447,6 +17878,14 @@ export type Subscription_Root = {
   packNftContract_by_pk?: Maybe<PackNftContract>;
   /** fetch data from the table in a streaming manner: "packNftContract" */
   packNftContract_stream: Array<PackNftContract>;
+  /** fetch data from the table: "packNftSupply" */
+  packNftSupply: Array<PackNftSupply>;
+  /** fetch aggregated fields from the table: "packNftSupply" */
+  packNftSupply_aggregate: PackNftSupply_Aggregate;
+  /** fetch data from the table: "packNftSupply" using primary key columns */
+  packNftSupply_by_pk?: Maybe<PackNftSupply>;
+  /** fetch data from the table in a streaming manner: "packNftSupply" */
+  packNftSupply_stream: Array<PackNftSupply>;
   /** fetch data from the table: "packOrderSums" */
   packOrderSums: Array<PackOrderSums>;
   /** fetch aggregated fields from the table: "packOrderSums" */
@@ -18009,6 +18448,36 @@ export type Subscription_RootPackNftContract_StreamArgs = {
 };
 
 
+export type Subscription_RootPackNftSupplyArgs = {
+  distinct_on?: InputMaybe<Array<PackNftSupply_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<PackNftSupply_Order_By>>;
+  where?: InputMaybe<PackNftSupply_Bool_Exp>;
+};
+
+
+export type Subscription_RootPackNftSupply_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<PackNftSupply_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  order_by?: InputMaybe<Array<PackNftSupply_Order_By>>;
+  where?: InputMaybe<PackNftSupply_Bool_Exp>;
+};
+
+
+export type Subscription_RootPackNftSupply_By_PkArgs = {
+  id: Scalars['uuid'];
+};
+
+
+export type Subscription_RootPackNftSupply_StreamArgs = {
+  batch_size: Scalars['Int'];
+  cursor: Array<InputMaybe<PackNftSupply_Stream_Cursor_Input>>;
+  where?: InputMaybe<PackNftSupply_Bool_Exp>;
+};
+
+
 export type Subscription_RootPackOrderSumsArgs = {
   distinct_on?: InputMaybe<Array<PackOrderSums_Select_Column>>;
   limit?: InputMaybe<Scalars['Int']>;
@@ -18449,6 +18918,23 @@ export type Timezone_Updates = {
   _set?: InputMaybe<Timezone_Set_Input>;
   /** filter the rows which have to be updated */
   where: Timezone_Bool_Exp;
+};
+
+/** Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'. */
+export type Uuid_Array_Comparison_Exp = {
+  /** is the array contained in the given array value */
+  _contained_in?: InputMaybe<Array<Scalars['uuid']>>;
+  /** does the array contain the given value */
+  _contains?: InputMaybe<Array<Scalars['uuid']>>;
+  _eq?: InputMaybe<Array<Scalars['uuid']>>;
+  _gt?: InputMaybe<Array<Scalars['uuid']>>;
+  _gte?: InputMaybe<Array<Scalars['uuid']>>;
+  _in?: InputMaybe<Array<Array<Scalars['uuid']>>>;
+  _is_null?: InputMaybe<Scalars['Boolean']>;
+  _lt?: InputMaybe<Array<Scalars['uuid']>>;
+  _lte?: InputMaybe<Array<Scalars['uuid']>>;
+  _neq?: InputMaybe<Array<Scalars['uuid']>>;
+  _nin?: InputMaybe<Array<Array<Scalars['uuid']>>>;
 };
 
 /** Boolean expression to compare columns of type "uuid". All fields are combined with logical 'AND'. */

--- a/libs/gql/user/api/src/generated/schema.graphql
+++ b/libs/gql/user/api/src/generated/schema.graphql
@@ -1636,10 +1636,10 @@ input EventCreateOneInlineInput {
 Model used to define the different locations and dates of an event. A festival or a tournament for instance could have several.
 """
 type EventDateLocation implements Entity {
-  """The end date including time on the UTC timezone."""
+  """The end date including time."""
   dateEnd: DateTime!
 
-  """The start date including time on the UTC timezone."""
+  """The start date including time."""
   dateStart: DateTime!
 
   """The unique identifier"""
@@ -5313,6 +5313,7 @@ type OrganizerConnection {
 }
 
 input OrganizerCreateInput {
+  clr7j9mmt0q2j01uo9zrs2fm7: PackCreateManyInlineInput
   createdAt: DateTime
 
   """description input for default locale (en)"""
@@ -5862,6 +5863,8 @@ enum OrganizerOrderByInput {
 }
 
 input OrganizerUpdateInput {
+  clr7j9mmt0q2j01uo9zrs2fm7: PackUpdateManyInlineInput
+
   """description input for default locale (en)"""
   description: RichTextAST
   discordWidgetId: String
@@ -6654,6 +6657,27 @@ type Pack implements Entity & Node {
   Permanent name associated with the NFT. Cannot be changed or localized.
   """
   nftName: String!
+  organizer(
+    """
+    Sets the locale of the parent document as the first locale in the fallback locales in the query's subtree.
+    
+    Note that `organizer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, localized entries that do not have the provided locale defined will be filtered out.
+    
+    This argument will affect any existing locale filtering defined in the query's tree for the subtree.
+    """
+    forceParentLocale: Boolean
+
+    """
+    Allows to optionally override locale filtering behaviour in the query's subtree.
+    
+    Note that `organizer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, localized entries that do not have the provided locale defined will be filtered out.
+    
+    This argument will overwrite any existing locale filtering defined in the query's tree for the subtree.
+    """
+    locales: [Locale!]
+  ): Organizer
 
   """The time the document was published. Null on documents in draft stage."""
   publishedAt(
@@ -6787,6 +6811,7 @@ input PackCreateInput {
   nftDescription: String!
   nftImage: AssetCreateOneInlineInput!
   nftName: String!
+  organizer: OrganizerCreateOneInlineInput
   updatedAt: DateTime
 }
 
@@ -7024,6 +7049,7 @@ input PackManyWhereInput {
 
   """All values starting with the given string."""
   nftName_starts_with: String
+  organizer: OrganizerWhereInput
   publishedAt: DateTime
 
   """All values greater than the given value."""
@@ -7107,6 +7133,7 @@ input PackUpdateInput {
   nftDescription: String
   nftImage: AssetUpdateOneInlineInput
   nftName: String
+  organizer: OrganizerUpdateOneInlineInput
 }
 
 input PackUpdateLocalizationDataInput {
@@ -7432,6 +7459,7 @@ input PackWhereInput {
 
   """All values starting with the given string."""
   nftName_starts_with: String
+  organizer: OrganizerWhereInput
   publishedAt: DateTime
 
   """All values greater than the given value."""
@@ -7537,10 +7565,7 @@ type PassOption implements Entity {
   """
   description: String
 
-  """
-  Define the location and date for this option.
-  Important ! It will determine the release and availability for the Pass access.
-  """
+  """Define the location and date for this option."""
   eventDateLocation(
     """
     Sets the locale of the resolved parent document as the only locale in the query's subtree.

--- a/libs/gql/user/api/src/generated/schema.json
+++ b/libs/gql/user/api/src/generated/schema.json
@@ -8147,7 +8147,7 @@
         "fields": [
           {
             "name": "dateEnd",
-            "description": "The end date including time on the UTC timezone.",
+            "description": "The end date including time.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -8163,7 +8163,7 @@
           },
           {
             "name": "dateStart",
-            "description": "The start date including time on the UTC timezone.",
+            "description": "The start date including time.",
             "args": [],
             "type": {
               "kind": "NON_NULL",
@@ -26183,6 +26183,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "clr7j9mmt0q2j01uo9zrs2fm7",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PackCreateManyInlineInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "createdAt",
             "description": null,
             "type": {
@@ -29157,6 +29169,18 @@
         "description": null,
         "fields": null,
         "inputFields": [
+          {
+            "name": "clr7j9mmt0q2j01uo9zrs2fm7",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "PackUpdateManyInlineInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "description",
             "description": "description input for default locale (en)",
@@ -33103,6 +33127,51 @@
             "deprecationReason": null
           },
           {
+            "name": "organizer",
+            "description": null,
+            "args": [
+              {
+                "name": "forceParentLocale",
+                "description": "Sets the locale of the parent document as the first locale in the fallback locales in the query's subtree.\n\nNote that `organizer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.\nThe first locale matching the provided list will be returned, localized entries that do not have the provided locale defined will be filtered out.\n\nThis argument will affect any existing locale filtering defined in the query's tree for the subtree.",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locales",
+                "description": "Allows to optionally override locale filtering behaviour in the query's subtree.\n\nNote that `organizer` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.\nThe first locale matching the provided list will be returned, localized entries that do not have the provided locale defined will be filtered out.\n\nThis argument will overwrite any existing locale filtering defined in the query's tree for the subtree.",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "Locale",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Organizer",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "publishedAt",
             "description": "The time the document was published. Null on documents in draft stage.",
             "args": [
@@ -33639,6 +33708,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizer",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "OrganizerCreateOneInlineInput",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -34938,6 +35019,18 @@
             "deprecationReason": null
           },
           {
+            "name": "organizer",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "OrganizerWhereInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "publishedAt",
             "description": null,
             "type": {
@@ -35401,6 +35494,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "organizer",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "OrganizerUpdateOneInlineInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -37113,6 +37218,18 @@
             "deprecationReason": null
           },
           {
+            "name": "organizer",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "OrganizerWhereInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "publishedAt",
             "description": null,
             "type": {
@@ -37601,7 +37718,7 @@
           },
           {
             "name": "eventDateLocation",
-            "description": "Define the location and date for this option.\nImportant ! It will determine the release and availability for the Pass access.",
+            "description": "Define the location and date for this option.",
             "args": [
               {
                 "name": "forceParentLocale",

--- a/libs/indexer/alchemy/webhooks/src/index.ts
+++ b/libs/indexer/alchemy/webhooks/src/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/nftActivity';
+export * from './lib/eventPassNftActivity';

--- a/libs/indexer/alchemy/webhooks/src/lib/common.ts
+++ b/libs/indexer/alchemy/webhooks/src/lib/common.ts
@@ -1,0 +1,113 @@
+import env from '@env/server';
+import { PackNftSupply_Updates } from '@gql/shared/types';
+import { AlchemyWrapper } from '@indexer/alchemy/admin';
+import type { Activity, AlchemyNFTActivityEvent } from '@indexer/alchemy/types';
+import { PackNftWrapper } from '@nft/event-pass';
+import { type NftTransferWithoutMetadata } from '@nft/types';
+import { ThirdwebSDK } from '@thirdweb-dev/sdk';
+import { hexToBigInt } from '@utils';
+import { Network } from 'alchemy-sdk';
+
+const alchemy = new AlchemyWrapper();
+
+const handleErc721Activity = async (
+  activity: Activity,
+  network: Network,
+  transactionHash: string,
+) => {
+  const {
+    fromAddress,
+    toAddress,
+    contractAddress,
+    blockNumber,
+    erc721TokenId,
+  } = activity;
+
+  if (!erc721TokenId) {
+    console.error(`No erc721TokenId found for ${transactionHash}`);
+    return null;
+  }
+
+  return {
+    fromAddress,
+    toAddress,
+    contractAddress,
+    blockNumber: hexToBigInt(blockNumber),
+    tokenId: hexToBigInt(erc721TokenId),
+    chainId: alchemy.convertNetworkToChainId(network).toString(),
+    transactionHash,
+  };
+};
+
+// https://docs.alchemy.com/reference/nft-activity-webhook
+const handleActivity = async (activity, network) => {
+  const {
+    category,
+    contractAddress,
+    fromAddress,
+    toAddress,
+    erc721TokenId,
+    log: { removed, transactionHash },
+  } = activity;
+  const packNftWrapper = new PackNftWrapper(
+    new ThirdwebSDK(env.CHAIN, { secretKey: env.THIRDWEB_SECRET_KEY }),
+  );
+
+  if (removed) {
+    console.error(
+      `NFT transfer: ${transactionHash} in ${network} for ${contractAddress} collection, fromAddress ${fromAddress} toAddress ${toAddress} with erc721TokenId ${erc721TokenId} was removed likely due to a reorg`,
+    );
+    return null;
+  }
+
+  let transfer;
+  let packUpdate;
+
+  if (category === 'erc721') {
+    transfer = await handleErc721Activity(activity, network, transactionHash);
+    return { transfer, packUpdate };
+  } else if (category === 'erc1155') {
+    try {
+      packUpdate = await packNftWrapper.handleErc1155Activity(
+        activity,
+        transactionHash,
+      );
+    } catch (error) {
+      console.error(
+        `Error handling ERC1155 activity for transaction ${transactionHash}:`,
+        error,
+      );
+      return null;
+    }
+    return { transfer, packUpdate };
+  }
+};
+
+export const extractNftTransfersFromEvent = async (
+  alchemyWebhookEvent: AlchemyNFTActivityEvent,
+) => {
+  const nftActivities = alchemyWebhookEvent.event.activity;
+  const network = alchemyWebhookEvent.event.network;
+  const nftTransfers: NftTransferWithoutMetadata[] = [];
+  let packUpdates: PackNftSupply_Updates[] = [];
+
+  if (!nftActivities?.length) {
+    throw new Error('No nft activities found in event');
+  }
+
+  for (const activity of nftActivities) {
+    const result = await handleActivity(activity, network);
+    if (result) {
+      if (result.transfer) {
+        nftTransfers.push(result.transfer);
+      }
+      if (Array.isArray(result.packUpdate)) {
+        packUpdates = [...packUpdates, ...result.packUpdate];
+      } else if (result.packUpdate) {
+        packUpdates.push(result.packUpdate);
+      }
+    }
+  }
+
+  return { nftTransfersFromEvent: nftTransfers, packUpdates };
+};

--- a/libs/indexer/alchemy/webhooks/src/lib/eventPassNftActivity.integration.test.ts
+++ b/libs/indexer/alchemy/webhooks/src/lib/eventPassNftActivity.integration.test.ts
@@ -7,7 +7,7 @@ import {
   deleteAllTables,
   type PgClient,
 } from '@test-utils/db';
-import { nftActivity } from './nftActivity';
+import { eventPassNftActivity } from './eventPassNftActivity';
 import { createMockAlchemyRequest } from './testUtils';
 
 // Mock the FileWrapper module
@@ -138,7 +138,7 @@ describe('nftActivity integration test', () => {
   });
 
   it('happy path with several nft activity being processed - no need to transfer QR code file', async () => {
-    const response = await nftActivity(
+    const response = await eventPassNftActivity(
       createMockAlchemyRequest([mockActivity]),
       'clizzpvidao620buvxit1ynko',
     );
@@ -154,7 +154,7 @@ describe('nftActivity integration test', () => {
   });
 
   it('happy path with several nft activity being processed - transfer of QR code file', async () => {
-    const response = await nftActivity(
+    const response = await eventPassNftActivity(
       createMockAlchemyRequest([mockActivity, mockActivity2]),
       'clizzpvidao620buvxit1ynko',
     );
@@ -185,7 +185,7 @@ describe('nftActivity integration test', () => {
   });
 
   it('happy path with several nft activity being processed - from different contractAddress', async () => {
-    const response = await nftActivity(
+    const response = await eventPassNftActivity(
       createMockAlchemyRequest([mockActivity, mockActivity2, mockActivity3]),
       'clizzpvidao620buvxit1ynko',
     );
@@ -224,7 +224,7 @@ describe('nftActivity integration test', () => {
 
   it('should log errors in case one NFT not found in DB', async () => {
     const consoleSpy = jest.spyOn(console, 'error');
-    const response = await nftActivity(
+    const response = await eventPassNftActivity(
       createMockAlchemyRequest([mockActivity, mockActivity4NoNft]),
       'clizzpvidao620buvxit1ynko',
     );
@@ -239,7 +239,7 @@ describe('nftActivity integration test', () => {
 
   it('should return error in case no NFT found in DB', async () => {
     const consoleSpy = jest.spyOn(console, 'error');
-    const response = await nftActivity(
+    const response = await eventPassNftActivity(
       createMockAlchemyRequest([mockActivity4NoNft]),
       'clizzpvidao620buvxit1ynko',
     );

--- a/libs/indexer/alchemy/webhooks/src/lib/eventPassNftActivity.ts
+++ b/libs/indexer/alchemy/webhooks/src/lib/eventPassNftActivity.ts
@@ -45,7 +45,7 @@ export async function eventPassNftActivity(
     await extractNftTransfersFromEvent(alchemyWebhookEvent);
   if (packUpdates.length) {
     try {
-      await adminSdk.UpdateEventPassPackMany({ updates: packUpdates });
+      await adminSdk.UpdatePackNftSupplyMany({ updates: packUpdates });
     } catch {
       return new Response('Error processing pack updates into hasura', {
         status: 500,

--- a/libs/indexer/alchemy/webhooks/src/lib/nftActivity.spec.ts
+++ b/libs/indexer/alchemy/webhooks/src/lib/nftActivity.spec.ts
@@ -1,10 +1,8 @@
 import type { Activity, AlchemyNFTActivityEvent } from '@indexer/alchemy/types';
 import { EventPassNftWrapper } from '@nft/event-pass';
 import { Network, WebhookType } from 'alchemy-sdk';
-import {
-  extractNftTransfersFromEvent,
-  nftActivity,
-} from './eventPassNftActivity';
+import { extractNftTransfersFromEvent } from './common';
+import { eventPassNftActivity } from './eventPassNftActivity';
 import { createMockAlchemyRequest } from './testUtils';
 import { isValidSignatureForAlchemyRequest } from './utils';
 
@@ -215,7 +213,7 @@ describe('extractNftTransfersFromEvent', () => {
 
 describe('nftActivity', () => {
   it('happy path with several nft activity being processed', async () => {
-    const response = await nftActivity(
+    const response = await eventPassNftActivity(
       createMockAlchemyRequest([mockActivity, mockActivity2]),
       'clizzpvidao620buvxit1ynko',
     );
@@ -230,7 +228,7 @@ describe('nftActivity', () => {
   it('should return error 500 when getEventPassNftTransfersMetadata returns empty array', async () => {
     getEventPassNftTransfersMetadataSpy.mockResolvedValue([]);
 
-    const response = await nftActivity(
+    const response = await eventPassNftActivity(
       createMockAlchemyRequest([mockActivity, mockActivity2]),
       'clizzpvidao620buvxit1ynko',
     );
@@ -242,7 +240,7 @@ describe('nftActivity', () => {
     // Override the validation to return false
     (isValidSignatureForAlchemyRequest as jest.Mock).mockReturnValueOnce(false);
 
-    const response = await nftActivity(
+    const response = await eventPassNftActivity(
       createMockAlchemyRequest([mockActivity, mockActivity2]),
       'clizzpvidao620buvxit1ynko',
     );
@@ -256,7 +254,7 @@ describe('nftActivity', () => {
       new Error('Test error'),
     );
 
-    const response = await nftActivity(
+    const response = await eventPassNftActivity(
       createMockAlchemyRequest([mockActivity, mockActivity2]),
       'clizzpvidao620buvxit1ynko',
     );
@@ -288,7 +286,7 @@ describe('nftActivity', () => {
       .fn()
       .mockResolvedValueOnce(JSON.stringify(invalidWebhookEvent));
 
-    const response = await nftActivity(
+    const response = await eventPassNftActivity(
       mockAlchemyRequest,
       'clizzpvidao620buvxit1ynko',
     );

--- a/libs/indexer/alchemy/webhooks/src/lib/nftActivity.spec.ts
+++ b/libs/indexer/alchemy/webhooks/src/lib/nftActivity.spec.ts
@@ -1,7 +1,10 @@
 import type { Activity, AlchemyNFTActivityEvent } from '@indexer/alchemy/types';
 import { EventPassNftWrapper } from '@nft/event-pass';
 import { Network, WebhookType } from 'alchemy-sdk';
-import { extractNftTransfersFromEvent, nftActivity } from './nftActivity';
+import {
+  extractNftTransfersFromEvent,
+  nftActivity,
+} from './eventPassNftActivity';
 import { createMockAlchemyRequest } from './testUtils';
 import { isValidSignatureForAlchemyRequest } from './utils';
 

--- a/libs/nft/event-pass/src/lib/index.ts
+++ b/libs/nft/event-pass/src/lib/index.ts
@@ -1,11 +1,29 @@
-import { adminSdk } from '@gql/admin/api';
-import type {
-  NftTransfer,
-  NftTransferWithoutMetadata,
-  NftTransferNotCreated,
-  EventPassNftAfterMutation,
-} from '@nft/types';
+import env from '@env/server';
 import { transferPassQrCodeBatch } from '@features/pass-api';
+import { adminSdk } from '@gql/admin/api';
+import {
+  NftTransfer_Insert_Input,
+  PackNftSupply_Updates,
+} from '@gql/shared/types';
+import { Activity } from '@indexer/alchemy/types';
+import {
+  ContractType,
+  RewardUnitsDistributed,
+  ThirdwebEventData,
+  type EventPassNftAfterMutation,
+  type NftTransfer,
+  type NftTransferNotCreated,
+  type NftTransferWithoutMetadata,
+} from '@nft/types';
+import { ThirdwebSDK, type ContractEvent } from '@thirdweb-dev/sdk';
+
+type HandleBundlesProps = {
+  numOfPacksOpened: number;
+  bundleSize: number;
+  nftToBundle: string[];
+  opener: string;
+  contractAddress: string;
+};
 
 export class EventPassNftWrapper {
   private adminSdk: typeof adminSdk;
@@ -116,5 +134,216 @@ export class EventPassNftWrapper {
     }
     if (nftFileTransfers.length === 0) return;
     await transferPassQrCodeBatch(nftFileTransfers);
+  }
+}
+
+export class PackNftWrapper {
+  private adminSdk: typeof adminSdk;
+  private thirdwebSDK: ThirdwebSDK;
+
+  constructor(thirdwebSDKInstance: ThirdwebSDK) {
+    this.adminSdk = adminSdk;
+    this.thirdwebSDK = thirdwebSDKInstance;
+  }
+
+  async getCurrentOwnerAddressByContractAndTokenId(
+    contractAddress: string,
+    tokenId: string,
+  ) {
+    try {
+      const response =
+        await this.adminSdk.GetCurrentOwnerAddressByContractAndTokenId({
+          contractAddress,
+          tokenId: BigInt(tokenId),
+        });
+      return response.eventPassNft[0];
+    } catch (error) {
+      console.error(
+        `Error getting current owner address by contract and token id: ${error}`,
+      );
+      throw new Error(
+        'Failed to get current owner address by contract and token id',
+      );
+    }
+  }
+
+  async getNftToBundle(
+    rewardUnitsDistributed: RewardUnitsDistributed,
+    opener: string,
+  ) {
+    try {
+      const nftToBundle = [];
+      for (const reward of rewardUnitsDistributed) {
+        const owner = await this.getCurrentOwnerAddressByContractAndTokenId(
+          reward.assetContract,
+          reward.tokenId,
+        );
+        if (owner.currentOwnerAddress !== opener) {
+          nftToBundle.push(owner.id);
+        }
+      }
+      return nftToBundle;
+    } catch (error) {
+      console.error(
+        `Error getting NFT to bundle for opener ${opener}: ${error}`,
+      );
+      throw new Error('Failed to get NFT to bundle');
+    }
+  }
+
+  async handleBundles({
+    numOfPacksOpened,
+    bundleSize,
+    nftToBundle,
+    opener,
+    contractAddress,
+  }: HandleBundlesProps) {
+    try {
+      const bundles = [];
+      for (let i = 0; i < numOfPacksOpened; i++) {
+        const start = i * bundleSize;
+        const end = start + bundleSize;
+        const bundle = nftToBundle.slice(start, end);
+        const pack =
+          await this.adminSdk.GetPackNftSupplyWithNullNftsFromCurrentOwnerAddress(
+            {
+              currentOwnerAddress: opener,
+              contractAddress,
+            },
+          );
+        bundles.push({
+          id: pack.packNftSupply[0].id,
+          newData: {
+            eventPassNfts: bundle,
+          },
+        });
+      }
+      return bundles;
+    } catch (error) {
+      console.error(
+        `Error handling bundles for opener ${opener} and contract ${contractAddress}: ${error}`,
+      );
+      throw new Error('Failed to handle bundles');
+    }
+  }
+
+  async handleEvent(
+    event: ContractEvent,
+    numOfPacksOpened: number,
+    contractAddress: string,
+  ) {
+    const { opener, rewardUnitsDistributed } = event.data as ThirdwebEventData;
+    const nftToBundle = await this.getNftToBundle(
+      rewardUnitsDistributed,
+      opener,
+    );
+    const bundleSize = nftToBundle.length / numOfPacksOpened;
+    return this.handleBundles({
+      numOfPacksOpened,
+      bundleSize,
+      nftToBundle,
+      opener,
+      contractAddress,
+    });
+  }
+
+  async handlePackOpenedEvents(
+    contractAddress: string,
+    blockNumber: string,
+    transactionHash: string,
+  ) {
+    let events: ContractEvent[];
+    try {
+      const pack = await this.thirdwebSDK.getContract(
+        contractAddress,
+        ContractType.PACK,
+      );
+      events = await pack.events.getEvents('PackOpened', {
+        fromBlock: blockNumber,
+        toBlock: 'latest',
+        order: 'desc',
+      });
+    } catch (error) {
+      throw new Error(`Failed to get contract or events: ${error.message}`);
+    }
+
+    const packUpdates = [];
+    for (const event of events) {
+      if (
+        event.transaction.blockNumber !== Number(blockNumber) ||
+        event.transaction.transactionHash !== transactionHash
+      )
+        continue;
+      const numOfPacksOpened = Number(event.data.numOfPacksOpened);
+      packUpdates.push(
+        await this.handleEvent(event, numOfPacksOpened, contractAddress),
+      );
+    }
+    return packUpdates;
+  }
+
+  async transferPackNftSupply(
+    amount: number,
+    nftTransferData: NftTransfer_Insert_Input,
+  ) {
+    const packUpdates: PackNftSupply_Updates[] = [];
+    try {
+      for (let i = 0; i < amount; i++) {
+        const pack = (
+          await this.adminSdk.GetPackNftSupplyWithNullNftsFromCurrentOwnerAddress(
+            {
+              currentOwnerAddress: nftTransferData.fromAddress,
+              contractAddress: nftTransferData.contractAddress,
+            },
+          )
+        ).packNftSupply[0];
+        const transfer = (
+          await adminSdk.UpsertNftTransfer({
+            objects: {
+              ...nftTransferData,
+              organizerId: pack.organizerId,
+            },
+          })
+        ).insert_nftTransfer;
+        packUpdates.push({
+          where: {
+            id: { _eq: pack.id },
+          },
+          _set: {
+            currentOwnerAddress: nftTransferData.toAddress,
+            lastNftTransferId: transfer.returning[0].id,
+          },
+        });
+      }
+    } catch (error) {
+      throw new Error(
+        `Failed to transfer Event Pass Pack from ${nftTransferData.fromAddress} to ${nftTransferData.toAddress}: ${error.message}`,
+      );
+    }
+    return packUpdates;
+  }
+
+  async handleErc1155Activity(activity: Activity, transactionHash: string) {
+    const { toAddress, fromAddress, contractAddress, blockNumber } = activity;
+
+    if (toAddress === '0x0000000000000000000000000000000000000000') {
+      return this.handlePackOpenedEvents(
+        contractAddress,
+        blockNumber,
+        transactionHash,
+      );
+    } else {
+      const erc1155Metadata = activity.erc1155Metadata;
+      const amount = Number(erc1155Metadata[0].value);
+      return this.transferPackNftSupply(amount, {
+        toAddress,
+        fromAddress,
+        contractAddress,
+        transactionHash,
+        chainId: env.CHAIN,
+        blockNumber: Number(blockNumber),
+        tokenId: 0,
+      });
+    }
   }
 }

--- a/libs/nft/thirdweb-organizer/src/action.ts
+++ b/libs/nft/thirdweb-organizer/src/action.ts
@@ -18,6 +18,7 @@ import type {
   EventPassNftContract_Insert_Input,
   EventPassNft_Insert_Input,
   PackNftContract_Insert_Input,
+  PackNftSupply_Insert_Input,
 } from '@gql/shared/types';
 import { defaultLocale } from '@next/i18n';
 import { ContractType } from '@nft/types';
@@ -63,6 +64,11 @@ export async function getEventPassNftContractNfts(
 ) {
   const data = await adminSdk.GetEventPassNftContractNfts(id);
   return data?.eventPassNftContract[0];
+}
+
+export async function createPackNftSupply(packs: PackNftSupply_Insert_Input[]) {
+  const data = await adminSdk.CreatePackNftSupply({ objects: packs });
+  return data?.insert_packNftSupply.affected_rows;
 }
 
 export async function createEventParametersAndWebhook({

--- a/libs/nft/thirdweb-organizer/src/index.ts
+++ b/libs/nft/thirdweb-organizer/src/index.ts
@@ -22,7 +22,9 @@ import {
   createEventPassNftContract,
   createEventPassNfts,
   createPackNftContract,
+  createPackNftSupply,
   getEventPassNftContractNfts,
+  getPackSupply,
   updateNftsWithPackId,
 } from './action';
 
@@ -460,6 +462,17 @@ class NftCollection {
       contractAddress: txResult,
     });
     if (!packNftContract) throw new Error('Error creating packNftContract');
+
+    const supply = await getPackSupply(txResult);
+
+    const packNftSupplyArray = new Array(supply.toNumber()).fill({
+      packId: packNftContract.packId,
+      contractAddress: txResult,
+      chainId: env.NEXT_PUBLIC_CHAIN,
+      organizerId,
+    });
+
+    await createPackNftSupply(packNftSupplyArray);
 
     const updates = selectedNfts.map((nft) => {
       return {

--- a/libs/nft/types/src/lib/index.ts
+++ b/libs/nft/types/src/lib/index.ts
@@ -72,3 +72,17 @@ export type RequiredEventPassNft = Required<
 export type EventPassNftContractNfts = NonNullable<
   GetEventPassNftContractNftsQuery['eventPassNftContract'][0]['eventPassNfts']
 >;
+
+export type ThirdwebEventData = {
+  packId: number;
+  opener: string;
+  numOfPacksOpened: number;
+  rewardUnitsDistributed: RewardUnitsDistributed;
+};
+
+export type RewardUnitsDistributed = {
+  assetContract: string;
+  tokenType: number;
+  tokenId: string;
+  totalAmount: number;
+}[];


### PR DESCRIPTION
## **User description**
…turn in packNftContract


___

## **Type**
Enhancement


___

## **Description**
- Introduced a new class `PackNftWrapper` in `libs/nft/event-pass/src/lib/index.ts` for handling NFT bundles, events, and transfers.
- Added new GraphQL mutations and queries to the admin SDK in `libs/gql/admin/api/src/generated/index.ts`.
- Created a new file `libs/indexer/alchemy/webhooks/src/lib/common.ts` for handling NFT activities and extracting NFT transfers from events.
- Refactored `libs/indexer/alchemy/webhooks/src/lib/eventPassNftActivity.ts` to use the new `extractNftTransfersFromEvent` function and added logic for handling pack updates.
- Updated tests in `libs/indexer/alchemy/webhooks/src/lib/eventPassNftActivity.integration.test.ts` to reflect these changes.
- Added new types in `libs/gql/admin/types/src/generated/index.ts` for the new GraphQL mutations and queries.
- Updated `libs/nft/thirdweb-organizer/src/index.ts` to create pack NFT supply when creating a new pack NFT contract.
- Added a new function `createPackNftSupply` in `libs/nft/thirdweb-organizer/src/action.ts` to create pack NFT supply in the database.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        libs/nft/event-pass/src/lib/index.ts<br><br>

**This file has been significantly expanded. A new class <br>`PackNftWrapper` has been added, which includes methods for <br>handling NFT bundles, events, and transfers. The <br>`EventPassNftWrapper` class has also been updated with new <br>import statements.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/229/files#diff-2aa6f8db10df438bc3c97673b7cfcc0084c36637b3e78162530db5b8d6123ca4"> +235/-6</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        libs/gql/admin/api/src/generated/index.ts<br><br>

**New GraphQL mutations and queries have been added to the <br>admin SDK, including `UpdatePackNftSupplyManyDocument`, <br>`CreatePackNftSupplyDocument`, and <br>`GetPackNftSupplyWithNullNftsFromCurrentOwnerAddressDocument`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/229/files#diff-a705910118ccb32a0fbdface4f59baf2452ffd8cdb25417f4774ef2c40fc5522"> +38/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>common.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        libs/indexer/alchemy/webhooks/src/lib/common.ts<br><br>

**This new file includes functions for handling NFT activities <br>and extracting NFT transfers from events. It also includes a <br>function `extractNftTransfersFromEvent` to extract NFT <br>transfers from Alchemy webhook events.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/229/files#diff-13c3127b987b9d875331517f2913fe01462233713e6d018d0ae1ee927173b252"> +113/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>eventPassNftActivity.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        libs/indexer/alchemy/webhooks/src/lib/eventPassNftActivity.ts<br><br>

**This file has been refactored to use the <br>`extractNftTransfersFromEvent` function from the new <br>`common.ts` file. It also includes new logic for handling <br>pack updates.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/229/files#diff-69ad28159b79035af8aee5e27e193afd281b043b72b574338c9245f58a1dad14"> +17/-46</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        libs/gql/admin/types/src/generated/index.ts<br><br>

**New types have been added for the new GraphQL mutations and <br>queries, including `UpdatePackNftSupplyManyMutation`, <br>`CreatePackNftSupplyMutation`, and <br>`GetPackNftSupplyWithNullNftsFromCurrentOwnerAddressQuery`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/229/files#diff-4422451788e8d06758e06954bb63de4ec1cf3a7dc5ee511d19b332e4615b3270"> +22/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        libs/nft/thirdweb-organizer/src/index.ts<br><br>

**This file has been updated to create pack NFT supply when <br>creating a new pack NFT contract.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/229/files#diff-80b26817489489d8498897af632d05d0f4662c8d8ebdcb70de6613f0297b72d6"> +13/-0</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>action.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        libs/nft/thirdweb-organizer/src/action.ts<br><br>

**A new function `createPackNftSupply` has been added to <br>create pack NFT supply in the database.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/229/files#diff-979b6ef9b050567219e1a772e5d6449136db534623283c47496e746df4235a35"> +6/-0</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>eventPassNftActivity.integration.test.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        libs/indexer/alchemy/webhooks/src/lib/eventPassNftActivity.integration.test.ts<br><br>

**The tests in this file have been updated to reflect the <br>changes in `eventPassNftActivity.ts`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/229/files#diff-d4b47773c5c2e512d5841572d6b1c62c5bd77742281b0712bf9dfc09e06a9cfe"> +6/-6</a></td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
