### PR TITLE
fix: switch exact match to expression matching

### DIFF
--- a/apps/back-office/e2e/humanResources.spec.ts
+++ b/apps/back-office/e2e/humanResources.spec.ts
@@ -43,8 +43,8 @@ test('human resources should not have access to events', async () => {
     goTo: '/en',
     role: Roles_Enum.OrganizerHumanResources,
   });
-  await expect(page.getByRole('link', { name: 'Manage Roles' })).toBeVisible();
+  await expect(page.getByRole('link', { name: /manage roles/i })).toBeVisible();
   await expect(
-    page.getByRole('link', { name: 'Event Management' }),
+    page.getByRole('link', { name: /event management/i }),
   ).toBeHidden();
 });

--- a/apps/back-office/e2e/superAdmin.spec.ts
+++ b/apps/back-office/e2e/superAdmin.spec.ts
@@ -43,36 +43,36 @@ test('super admin should be able to view events', async () => {
     goTo: '/en',
     role: Roles_Enum.OrganizerSuperAdmin,
   });
-  await page.getByRole('link', { name: 'Events Management' }).click();
-  await expect(page.getByText('An event')).toBeVisible();
-  await expect(page.getByText('test-an-event')).toBeVisible();
+  await page.getByRole('link', { name: /events management/i }).click();
+  await expect(page.getByText(/an event/i)).toBeVisible();
+  await expect(page.getByText(/test-an-event/i)).toBeVisible();
   await expect(
-    page.getByRole('heading', { name: 'Events Management' }),
+    page.getByRole('heading', { name: /events management/i }),
   ).toBeVisible();
-  await expect(page.getByText('Anniversaire', { exact: true })).toBeVisible();
-  await expect(page.getByText('test-anniversaire')).toBeVisible();
+  await expect(page.getByText(/^anniversaire$/i)).toBeVisible();
+  await expect(page.getByText(/test-anniversaire/i)).toBeVisible();
   await page
-    .getByRole('row', { name: 'An event test-an-event' })
+    .getByRole('row', { name: /an event test-an-event/i })
     .getByRole('button')
     .click();
-  await page.getByRole('link', { name: 'Edit Edit' }).click();
-  await expect(page.getByRole('heading', { name: 'An event' })).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'Gold' })).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'VIP' })).toBeVisible();
-  await expect(page.getByText('Pass vip pour le match')).toBeVisible();
-  await expect(page.getByText('Pass gold pour le match')).toBeVisible();
+  await page.getByRole('link', { name: /edit edit/i }).click();
+  await expect(page.getByRole('heading', { name: /an event/i })).toBeVisible();
+  await expect(page.getByRole('heading', { name: /gold/i })).toBeVisible();
+  await expect(page.getByRole('heading', { name: /vip/i })).toBeVisible();
+  await expect(page.getByText(/pass vip pour le match/i)).toBeVisible();
+  await expect(page.getByText(/pass gold pour le match/i)).toBeVisible();
   await page
-    .getByRole('button', { name: 'Pass associated to your NFTs' })
+    .getByRole('button', { name: /pass associated to your nfts/i })
     .first()
     .click();
   await expect(
-    page.getByRole('button', { name: 'Deploy the NFTs contract' }).first(),
+    page.getByRole('button', { name: /deploy the nfts contract/i }).first(),
   ).toBeVisible();
   await expect(
     page.locator('span').filter({ hasText: '0xfake***ddress1' }).first(),
   ).toBeVisible();
   await page.getByTestId('sheet-back').click();
   await expect(
-    page.getByRole('heading', { name: 'Events Management' }),
+    page.getByRole('heading', { name: /events management/i }),
   ).toBeVisible();
 });

--- a/apps/web/e2e/event.spec.ts
+++ b/apps/web/e2e/event.spec.ts
@@ -51,25 +51,25 @@ test('user should be able to buy a pass', async () => {
     user: 'alpha_user',
     goTo: '/en/organizer/test/event/test-an-event',
   });
-  await expect(page.getByRole('img', { name: 'An event' })).toBeVisible();
-  await expect(page.getByText('Wed, Jun 28, 2023, 2:08 PM')).toBeVisible();
-  await expect(page.getByText('Thu, Jun 22, 2023, 8:40 PM')).toBeVisible();
+  await expect(page.getByRole('img', { name: /an event/i })).toBeVisible();
+  await expect(page.getByText(/wed, jun 28, 2023, 2:08 pm/i)).toBeVisible();
+  await expect(page.getByText(/thu, jun 22, 2023, 8:40 pm/i)).toBeVisible();
   await page
-    .getByRole('button', { name: 'Qr Code Select passes' })
+    .getByRole('button', { name: /qr code select passes/i })
     .first()
     .click();
   await page
     .locator('div')
-    .filter({ hasText: /^€82\.500$/ })
-    .getByLabel('increment value')
+    .filter({ hasText: /^€82\.500$/i })
+    .getByLabel(/increment value/i)
     .click();
-  await expect(page.getByText('1 pass selected')).toBeVisible();
+  await expect(page.getByText(/1 pass selected/i)).toBeVisible();
   await expect(
-    page.getByRole('heading', { name: 'Total Price: €82.50' }),
+    page.getByRole('heading', { name: /total price: €82.50/i }),
   ).toBeVisible();
-  await page.getByRole('button', { name: 'Go to payment' }).click();
-  await page.getByRole('button', { name: 'Proceed to payment' }).click();
-  await page.waitForURL(/checkout.stripe.com\/c\/pay/);
-  await page.getByLabel('Back').click();
-  await expect(page.getByText('Purchase Cancelled')).toBeVisible();
+  await page.getByRole('button', { name: /go to payment/i }).click();
+  await page.getByRole('button', { name: /proceed to payment/i }).click();
+  await page.waitForURL(/checkout.stripe.com\/c\/pay/i);
+  await page.getByLabel(/back/i).click();
+  await expect(page.getByText(/purchase cancelled/i)).toBeVisible();
 });

--- a/apps/web/e2e/pass.spec.ts
+++ b/apps/web/e2e/pass.spec.ts
@@ -51,25 +51,26 @@ test.beforeEach(async () => {
 });
 test('user should be able to download and reveal his pass', async () => {
   const { page, account } = await loadAccount({ user: 'alpha_user' });
-  await page.getByRole('link', { name: 'Qr Code Pass' }).click();
-  await page.getByRole('tab', { name: 'Past' }).click();
-  await expect(page.getByText('Pass #12,432Revealed')).toBeVisible();
-  await expect(page.getByText('Pass #1,234,124Not revealed')).toBeVisible();
+  await page.getByRole('link', { name: /qr code pass/i }).click();
+  await page.getByRole('tab', { name: /past/i }).click();
+  await expect(page.getByText(/pass #12,432revealed/i)).toBeVisible();
+  await expect(page.getByText(/pass #1,234,124not revealed/i)).toBeVisible();
+  await page.getByText(/download 2 passes/i).click();
+  await page.getByRole('button', { name: /reveal yes, reveal it/i }).click();
   await page
-    .getByRole('button', { name: 'Download Download 2 passes' })
+    .getByRole('button', { name: /menu actions/i })
+    .nth(1)
     .click();
-  await page.getByRole('button', { name: 'Reveal Yes, reveal it' }).click();
-  await page.getByRole('button', { name: 'Menu Actions' }).nth(1).click();
   const downloadPromise = page.waitForEvent('download');
-  await page.getByRole('link', { name: 'Download Download' }).click();
+  await page.locator(':text-is("Download")').click();
   const download = await downloadPromise;
-  await expect(page.getByText('Pass downloaded').nth(1)).toBeVisible();
+  await expect(page.getByText(/pass downloaded/i).nth(1)).toBeVisible();
   await expect(
-    page.getByText('The pass has been downloaded').nth(1),
+    page.getByText(/the pass has been downloaded/i).nth(1),
   ).toBeVisible();
   const downloadFilename = download.suggestedFilename();
   expect(downloadFilename).toEqual('test-an-event-vip-12432.png');
   expect(await download.failure()).toBeFalsy();
   await page.reload();
-  await expect(page.getByText('Pass #1,234,124Revealed')).toBeVisible();
+  await expect(page.getByText(/pass #1,234,124revealed/i)).toBeVisible();
 });

--- a/libs/nft/thirdweb-organizer/src/index.ts
+++ b/libs/nft/thirdweb-organizer/src/index.ts
@@ -277,6 +277,7 @@ export class NftCollection {
         {
           name,
           primary_sale_recipient: address,
+          platform_fee_recipient: address,
           voting_token_address: address,
         },
       );
@@ -500,6 +501,7 @@ export class PackCollection {
       {
         name: pack.name,
         primary_sale_recipient: address,
+        platform_fee_recipient: address,
         voting_token_address: address,
       },
     );


### PR DESCRIPTION
## **User description**
Playwwright provide two possibilities to match text in a page without exact match:

- **page.locator(':text-matches("REGEX")')**  match a regular expression in the page
- **page.locator(':text-is("Download 2 passes")')** matches the **smallest element** in the page with exact text.

In order to remove _Download Download_ or even _Download 2 passes_ text-is has been prefered to match and remove the first useless Download that was just here for an exact match since the number of pass is known in the test.


___

## **Type**
Bug fix


___

## **Description**
- The PR addresses an issue in the end-to-end test 'user should be able to download and reveal his pass' in the file `pass.spec.ts`.
- Previously, the test was using exact match to find and interact with elements on the page. This was causing issues as it was matching unnecessary text.
- The PR fixes this by switching from exact match to expression matching. This ensures that only the intended elements are matched and interacted with.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pass.spec.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        apps/web/e2e/pass.spec.ts<br><br>

**The PR replaces the method of matching text in the page from <br>exact match to expression matching. This is done to avoid <br>matching unnecessary text. The changes are made in the test <br>'user should be able to download and reveal his pass'.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/236/files#diff-57a509995a0017d6cc351be2e564f1761e096b943410f94bb7decad684d4bd11"> +2/-4</a></td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
