### PR TITLE
pages/api: change claim order route to use nextApi type instead

### DIFF
--- a/apps/web/pages/api/order/claim/[id]/index.ts
+++ b/apps/web/pages/api/order/claim/[id]/index.ts
@@ -1,22 +1,27 @@
 import { adminSdk } from '@gql/admin/api';
 import { NftClaimable } from '@nft/thirdweb-admin';
+import { NextApiRequest, NextApiResponse } from 'next';
 
 export const maxDuration = 300;
 
-// This route has been moved to pages/api regarding a Thirdweb and NextJS 14 error, it should be moved back into app/api when the error will be fix https://github.com/AlexandreG-tech/Server-Action-Error
-export default async function handler(req: Request, { params: { id } }) {
-  const order = (await adminSdk.GetOrderFromId({ id })).order_by_pk;
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const { id } = req.query;
+  const order = (await adminSdk.GetOrderFromId({ id: id as string }))
+    .order_by_pk;
   const nft = new NftClaimable();
 
   if (!order) {
-    return Response.error();
+    return res.status(400).json({ error: 'Order not found' });
   }
 
   try {
     await nft.claimOrder(order);
-    return Response.json({ status: 'success', id });
+    return res.status(200).json({ status: 'success', id });
   } catch (e) {
     console.error(e);
-    return Response.error();
+    return res.status(500).json({ error: 'An error occurred' });
   }
 }

--- a/apps/web/pages/api/order/claim/[id]/index.ts
+++ b/apps/web/pages/api/order/claim/[id]/index.ts
@@ -4,6 +4,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 export const maxDuration = 300;
 
+// This route has been moved to pages/api regarding a Thirdweb and NextJS 14 error, it should be moved back into app/api when the error will be fix https://github.com/AlexandreG-tech/Server-Action-Error
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,

--- a/apps/web/pages/api/webhooks/payment/stripe/checkout/index.ts
+++ b/apps/web/pages/api/webhooks/payment/stripe/checkout/index.ts
@@ -8,6 +8,7 @@ export const config = {
   },
 };
 
+// This route has been moved to pages/api regarding a Thirdweb and NextJS 14 error, it should be moved back into app/api when the error will be fix https://github.com/AlexandreG-tech/Server-Action-Error
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,

--- a/apps/web/pages/api/webhooks/payment/stripe/checkout/index.ts
+++ b/apps/web/pages/api/webhooks/payment/stripe/checkout/index.ts
@@ -1,8 +1,33 @@
+import { Payment } from '@payment/admin';
 import { stripeCheckoutStatus } from '@payment/webhooks';
+import { NextApiRequest, NextApiResponse } from 'next';
 
-export const maxDuration = 30;
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
 
-// This route has been moved to pages/api regarding a Thirdweb and NextJS 14 error, it should be moved back into app/api when the error will be fix https://github.com/AlexandreG-tech/Server-Action-Error
-export default async function handler(req: Request) {
-  return stripeCheckoutStatus(req);
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  const buffer = await new Promise<Buffer>((resolve, reject) => {
+    let data = Buffer.alloc(0);
+    req.on('data', (chunk) => {
+      data = Buffer.concat([data, chunk]);
+    });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+
+  const payload = buffer.toString();
+  const signature = req.headers['stripe-signature'] as string;
+
+  const response = await stripeCheckoutStatus(
+    new Payment(),
+    signature,
+    payload,
+  );
+  res.status(response.status).json(response.body);
 }

--- a/libs/payment/webhooks/src/lib/payment-webhooks.spec.ts
+++ b/libs/payment/webhooks/src/lib/payment-webhooks.spec.ts
@@ -29,9 +29,8 @@ jest.mock('next/headers', () => ({
   headers: () => mockHeaders,
 }));
 
-const mockRequest: Request = {
-  text: jest.fn().mockReturnValue('body'),
-} as unknown as Request;
+const mockPayload = 'body';
+const mockSignature = 'Stripe-Signature';
 
 describe('stripeCheckoutStatus', () => {
   beforeEach(() => {
@@ -51,7 +50,11 @@ describe('stripeCheckoutStatus', () => {
   });
 
   it('should handle complete event successfully', async () => {
-    const result = await stripeCheckoutStatus(mockRequest, mockPayment);
+    const result = await stripeCheckoutStatus(
+      mockPayment,
+      mockSignature,
+      mockPayload,
+    );
 
     expect(mockPayment.webhookStripeConstructEvent).toHaveBeenCalledWith({
       body: 'body',
@@ -74,7 +77,11 @@ describe('stripeCheckoutStatus', () => {
       },
     });
 
-    const result = await stripeCheckoutStatus(mockRequest, mockPayment);
+    const result = await stripeCheckoutStatus(
+      mockPayment,
+      mockSignature,
+      mockPayload,
+    );
 
     expect(mockPayment.canceledStripeCheckoutSession).toHaveBeenCalledWith({
       stripeCheckoutSessionId: 'checkoutSessionId',
@@ -89,7 +96,12 @@ describe('stripeCheckoutStatus', () => {
         throw new Error('Error constructing event');
       });
 
-    const result = await stripeCheckoutStatus(mockRequest, mockPayment);
+    const result = await stripeCheckoutStatus(
+      mockPayment,
+      mockSignature,
+      mockPayload,
+    );
+
     expect(result.status).toEqual(400);
   });
 
@@ -100,7 +112,11 @@ describe('stripeCheckoutStatus', () => {
         throw new Error('Error confirming checkout session');
       });
     mockPayment.refundPayment = jest.fn();
-    const result = await stripeCheckoutStatus(mockRequest, mockPayment);
+    const result = await stripeCheckoutStatus(
+      mockPayment,
+      mockSignature,
+      mockPayload,
+    );
 
     expect(mockPayment.refundPayment).not.toHaveBeenCalled();
     expect(result.status).toEqual(500);
@@ -115,7 +131,11 @@ describe('stripeCheckoutStatus', () => {
 
     mockPayment.refundPayment = jest.fn();
 
-    const result = await stripeCheckoutStatus(mockRequest, mockPayment);
+    const result = await stripeCheckoutStatus(
+      mockPayment,
+      mockSignature,
+      mockPayload,
+    );
 
     expect(mockPayment.refundPayment).not.toHaveBeenCalled();
     expect(result.status).toEqual(500);
@@ -142,7 +162,11 @@ describe('stripeCheckoutStatus', () => {
       });
     mockPayment.refundPayment = jest.fn();
 
-    const result = await stripeCheckoutStatus(mockRequest, mockPayment);
+    const result = await stripeCheckoutStatus(
+      mockPayment,
+      mockSignature,
+      mockPayload,
+    );
 
     expect(mockPayment.refundPayment).toHaveBeenCalledWith({
       paymentIntentId: 'paymentIntentId',
@@ -175,7 +199,11 @@ describe('stripeCheckoutStatus', () => {
       throw new Error('Error refunding payment');
     });
 
-    const result = await stripeCheckoutStatus(mockRequest, mockPayment);
+    const result = await stripeCheckoutStatus(
+      mockPayment,
+      mockSignature,
+      mockPayload,
+    );
 
     expect(mockPayment.refundPayment).toHaveBeenCalledWith({
       paymentIntentId: 'paymentIntentId',
@@ -200,7 +228,12 @@ describe('stripeCheckoutStatus', () => {
         throw new Error('Error canceling checkout session');
       });
 
-    const result = await stripeCheckoutStatus(mockRequest, mockPayment);
+    const result = await stripeCheckoutStatus(
+      mockPayment,
+      mockSignature,
+      mockPayload,
+    );
+
     expect(result.status).toEqual(400);
   });
 
@@ -225,7 +258,7 @@ describe('stripeCheckoutStatus', () => {
       });
     mockPayment.refundPayment = jest.fn();
 
-    await stripeCheckoutStatus(mockRequest, mockPayment);
+    await stripeCheckoutStatus(mockPayment, mockSignature, mockPayload);
 
     expect(mockPayment.refundPayment).toHaveBeenCalledWith({
       paymentIntentId: 'paymentIntentId',
@@ -254,7 +287,7 @@ describe('stripeCheckoutStatus', () => {
       });
     mockPayment.refundPayment = jest.fn();
 
-    await stripeCheckoutStatus(mockRequest, mockPayment);
+    await stripeCheckoutStatus(mockPayment, mockSignature, mockPayload);
 
     expect(mockPayment.refundPayment).not.toHaveBeenCalledWith();
   });

--- a/libs/payment/webhooks/src/lib/payment-webhooks.ts
+++ b/libs/payment/webhooks/src/lib/payment-webhooks.ts
@@ -4,7 +4,6 @@ import {
   StripeCheckoutSessionEnum,
   StripeEvent,
 } from '@payment/types';
-import { headers } from 'next/headers';
 
 // const payment = new Payment();
 
@@ -27,14 +26,16 @@ const stripeCheckoutSessionEvents = [
 // };
 
 export async function stripeCheckoutStatus(
-  req: Request,
   payment: Payment = new Payment(),
+  signature: string,
+  payload: string,
 ) {
-  const body = await req.text();
-  const signature = headers().get('Stripe-Signature') as string;
   let event: StripeEvent;
   try {
-    event = payment.webhookStripeConstructEvent({ body, signature });
+    event = payment.webhookStripeConstructEvent({
+      body: payload,
+      signature,
+    });
     console.log({ event });
     if (
       !stripeCheckoutSessionEvents.includes(


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
This PR contains enhancements to the API routes and the payment webhooks library. The main changes are:
- The API route handlers have been refactored to use the NextApiRequest and NextApiResponse types from Next.js for the request and response objects. This improves type safety and error handling.
- The stripeCheckoutStatus function in the payment webhooks library has been refactored to take a signature and a payload as arguments instead of a request object. This makes the function more flexible and easier to test.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        apps/web/pages/api/order/claim/[id]/index.ts<br><br>

**The handler function in this file has been refactored to use <br>NextApiRequest and NextApiResponse types from Next.js for <br>the request and response objects. This change improves type <br>safety and error handling. The error responses now return a <br>JSON object with an error message instead of just an error <br>status. The id is now extracted from the request query <br>instead of the params.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/257/files#diff-01f449dc3dbb24ab53b88505730ca0968f081056aad5605762317844b052ac0c"> +11/-6</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        apps/web/pages/api/webhooks/payment/stripe/checkout/index.ts<br><br>

**The handler function in this file has been refactored to use <br>NextApiRequest and NextApiResponse types from Next.js for <br>the request and response objects. The function now reads the <br>request data into a buffer, converts it to a string, and <br>passes it along with the stripe-signature header to the <br>stripeCheckoutStatus function. The config object has been <br>added to disable the default body parser.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/257/files#diff-3329d8360a1496db97e13a84df7ff799a8c469408d0056c3dacc375d12b756a0"> +29/-4</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>payment-webhooks.ts&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        libs/payment/webhooks/src/lib/payment-webhooks.ts<br><br>

**The stripeCheckoutStatus function has been refactored to <br>take a signature and a payload as arguments instead of a <br>request object. The function now constructs the Stripe event <br>using these arguments. This change makes the function more <br>flexible and easier to test as it no longer depends on the <br>request object.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/257/files#diff-7559362a4e5d9b2a85894302f2dea2e198975c52265521daf3f39fa157b100ba"> +6/-5</a></td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
