### PR TITLE
238 dca 2 create database model for content space parameters

### DIFF
--- a/hasura/app/metadata/databases/default/tables/public_contentSpaceParameters.yaml
+++ b/hasura/app/metadata/databases/default/tables/public_contentSpaceParameters.yaml
@@ -1,0 +1,15 @@
+table:
+  name: contentSpaceParameters
+  schema: public
+remote_relationships:
+  - definition:
+      to_remote_schema:
+        lhs_fields:
+          - contentSpaceId
+        remote_field:
+          contentSpace:
+            arguments:
+              where:
+                id: $contentSpaceId
+        remote_schema: Hygraph CMS Remote Schema
+    name: contentSpace

--- a/hasura/app/metadata/databases/default/tables/public_contentSpaceStatus.yaml
+++ b/hasura/app/metadata/databases/default/tables/public_contentSpaceStatus.yaml
@@ -1,0 +1,4 @@
+table:
+  name: contentSpaceStatus
+  schema: public
+is_enum: true

--- a/hasura/app/metadata/databases/default/tables/tables.yaml
+++ b/hasura/app/metadata/databases/default/tables/tables.yaml
@@ -1,4 +1,6 @@
 - "!include public_account.yaml"
+- "!include public_contentSpaceParameters.yaml"
+- "!include public_contentSpaceStatus.yaml"
 - "!include public_currency.yaml"
 - "!include public_eventParameters.yaml"
 - "!include public_eventPassNft.yaml"

--- a/hasura/app/metadata/remote_schemas.yaml
+++ b/hasura/app/metadata/remote_schemas.yaml
@@ -54,3 +54,15 @@
                 schema: public
           name: eventParameters
       type_name: Event
+    - relationships:
+        - definition:
+            to_source:
+              field_mapping:
+                id: contentSpaceId
+              relationship_type: object
+              source: default
+              table:
+                name: contentSpaceParameters
+                schema: public
+          name: contentSpaceParameters
+      type_name: ContentSpace

--- a/hasura/app/migrations/default/1706105882414_contentSpaceParameters/down.sql
+++ b/hasura/app/migrations/default/1706105882414_contentSpaceParameters/down.sql
@@ -1,0 +1,33 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- -- Create contentSpaceStatus table
+-- CREATE TABLE public."contentSpaceStatus"(
+--   value text NOT NULL
+-- );
+--
+-- ALTER TABLE ONLY public."contentSpaceStatus"
+--   ADD CONSTRAINT "contentSpaceStatus_pkey" PRIMARY KEY (value);
+--
+-- INSERT INTO public."contentSpaceStatus"(value)
+--   VALUES ('DRAFT'),
+-- ('PUBLISHED');
+--
+-- -- Create contentSpaceParameters table
+-- CREATE TABLE "public"."contentSpaceParameters" (
+--   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+--   "contentSpaceId" text NOT NULL UNIQUE,
+--   "status" text DEFAULT 'DRAFT' REFERENCES "public"."contentSpaceStatus"("value") ON UPDATE NO action ON DELETE NO action,
+--   "created_at" timestamptz NOT NULL DEFAULT now(),
+--   "updated_at" timestamptz NOT NULL DEFAULT now(),
+--   "organizerId" text NOT NULL
+-- );
+--
+-- COMMENT ON TABLE "public"."contentSpaceParameters" IS E'The contentSpaceParameters model is designed to define properties specifically for content spaces. This table includes essential details like the contentSpaceId, which links to the specific content space. By centralizing this information, our system can effectively manage and control parameters tied to each content space, enhancing functionality and flexibility.';
+--
+-- COMMENT ON COLUMN "public"."contentSpaceParameters"."contentSpaceId" IS E'It stores the identifier for the content space. This ID is crucial for managing and linking specific parameters to each content space, ensuring accurate and efficient handling of content space-related data.';
+--
+-- -- Create trigger for contentSpaceParameters
+-- CREATE TRIGGER set_contentSpaceParameters_updated_at
+--   BEFORE UPDATE ON "public"."contentSpaceParameters"
+--   FOR EACH ROW
+--   EXECUTE FUNCTION public.set_current_timestamp_updated_at();

--- a/hasura/app/migrations/default/1706105882414_contentSpaceParameters/up.sql
+++ b/hasura/app/migrations/default/1706105882414_contentSpaceParameters/up.sql
@@ -1,0 +1,31 @@
+-- Create contentSpaceStatus table
+CREATE TABLE public."contentSpaceStatus"(
+  value text NOT NULL
+);
+
+ALTER TABLE ONLY public."contentSpaceStatus"
+  ADD CONSTRAINT "contentSpaceStatus_pkey" PRIMARY KEY (value);
+
+INSERT INTO public."contentSpaceStatus"(value)
+  VALUES ('DRAFT'),
+('PUBLISHED');
+
+-- Create contentSpaceParameters table
+CREATE TABLE "public"."contentSpaceParameters" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "contentSpaceId" text NOT NULL UNIQUE,
+  "status" text DEFAULT 'DRAFT' REFERENCES "public"."contentSpaceStatus"("value") ON UPDATE NO action ON DELETE NO action,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  "organizerId" text NOT NULL
+);
+
+COMMENT ON TABLE "public"."contentSpaceParameters" IS E'The contentSpaceParameters model is designed to define properties specifically for content spaces. This table includes essential details like the contentSpaceId, which links to the specific content space. By centralizing this information, our system can effectively manage and control parameters tied to each content space, enhancing functionality and flexibility.';
+
+COMMENT ON COLUMN "public"."contentSpaceParameters"."contentSpaceId" IS E'It stores the identifier for the content space. This ID is crucial for managing and linking specific parameters to each content space, ensuring accurate and efficient handling of content space-related data.';
+
+-- Create trigger for contentSpaceParameters
+CREATE TRIGGER set_contentSpaceParameters_updated_at
+  BEFORE UPDATE ON "public"."contentSpaceParameters"
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_current_timestamp_updated_at();

--- a/libs/gql/admin/api/src/generated/index.ts
+++ b/libs/gql/admin/api/src/generated/index.ts
@@ -46,6 +46,26 @@ export const OrganizerFieldsFragmentDoc = `
   imageClasses
 }
     `;
+export const ContentSpaceFieldsFragmentDoc = `
+    fragment ContentSpaceFields on ContentSpace {
+  title
+  slug
+  heroImage {
+    url
+  }
+  description {
+    json
+    references {
+      ... on Asset {
+        __typename
+        id
+        url
+        mimeType
+      }
+    }
+  }
+}
+    `;
 export const EventListFieldsFragmentDoc = `
     fragment EventListFields on Event {
   id
@@ -434,6 +454,50 @@ ${KycFieldsFragmentDoc}`;
   }
 }
     ${NftTransferFieldsFragmentDoc}`;
+ const GetContentSpaceFromOrganizerIdTableDocument = `
+    query GetContentSpaceFromOrganizerIdTable($id: ID!, $locale: Locale!, $stage: Stage!) @cached {
+  organizer(where: {id: $id}, locales: [$locale, en], stage: $stage) {
+    contentSpaces {
+      slug
+      title
+      contentSpaceParameters {
+        status
+      }
+    }
+  }
+}
+    `;
+ const GetContentSpaceWithEventPassesOrganizerDocument = `
+    query GetContentSpaceWithEventPassesOrganizer($slug: String!, $locale: Locale!, $stage: Stage!) @cached {
+  contentSpace(where: {slug: $slug}, locales: [$locale, en], stage: $stage) {
+    title
+    slug
+    heroImage {
+      url
+    }
+    contentSpaceParameters {
+      status
+    }
+    eventPasses(forceParentLocale: true) {
+      ... on EventPass {
+        id
+        name
+        event {
+          slug
+          title
+        }
+      }
+    }
+  }
+}
+    `;
+ const CreateContentSpaceParametersDocument = `
+    mutation CreateContentSpaceParameters($object: contentSpaceParameters_insert_input!) {
+  insert_contentSpaceParameters_one(object: $object) {
+    id
+  }
+}
+    `;
  const GetEventDocument = `
     query GetEvent($slug: String!, $locale: Locale!, $stage: Stage!) @cached {
   event(where: {slug: $slug}, locales: [$locale, en], stage: $stage) {
@@ -1188,6 +1252,15 @@ export function getSdk<C, E>(requester: Requester<C, E>) {
     },
     GetNftTransferByTokenIdAndCollection(variables: Types.GetNftTransferByTokenIdAndCollectionQueryVariables, options?: C): Promise<Types.GetNftTransferByTokenIdAndCollectionQuery> {
       return requester<Types.GetNftTransferByTokenIdAndCollectionQuery, Types.GetNftTransferByTokenIdAndCollectionQueryVariables>(GetNftTransferByTokenIdAndCollectionDocument, variables, options) as Promise<Types.GetNftTransferByTokenIdAndCollectionQuery>;
+    },
+    GetContentSpaceFromOrganizerIdTable(variables: Types.GetContentSpaceFromOrganizerIdTableQueryVariables, options?: C): Promise<Types.GetContentSpaceFromOrganizerIdTableQuery> {
+      return requester<Types.GetContentSpaceFromOrganizerIdTableQuery, Types.GetContentSpaceFromOrganizerIdTableQueryVariables>(GetContentSpaceFromOrganizerIdTableDocument, variables, options) as Promise<Types.GetContentSpaceFromOrganizerIdTableQuery>;
+    },
+    GetContentSpaceWithEventPassesOrganizer(variables: Types.GetContentSpaceWithEventPassesOrganizerQueryVariables, options?: C): Promise<Types.GetContentSpaceWithEventPassesOrganizerQuery> {
+      return requester<Types.GetContentSpaceWithEventPassesOrganizerQuery, Types.GetContentSpaceWithEventPassesOrganizerQueryVariables>(GetContentSpaceWithEventPassesOrganizerDocument, variables, options) as Promise<Types.GetContentSpaceWithEventPassesOrganizerQuery>;
+    },
+    CreateContentSpaceParameters(variables: Types.CreateContentSpaceParametersMutationVariables, options?: C): Promise<Types.CreateContentSpaceParametersMutation> {
+      return requester<Types.CreateContentSpaceParametersMutation, Types.CreateContentSpaceParametersMutationVariables>(CreateContentSpaceParametersDocument, variables, options) as Promise<Types.CreateContentSpaceParametersMutation>;
     },
     GetEvent(variables: Types.GetEventQueryVariables, options?: C): Promise<Types.GetEventQuery> {
       return requester<Types.GetEventQuery, Types.GetEventQueryVariables>(GetEventDocument, variables, options) as Promise<Types.GetEventQuery>;

--- a/libs/gql/admin/api/src/generated/schema.graphql
+++ b/libs/gql/admin/api/src/generated/schema.graphql
@@ -1150,6 +1150,8 @@ input ConnectPositionInput {
 The ContentSpace model is a core component in delivering exclusive, NFT-linked digital content. It serves as a hub for organizers to manage and distribute unique content accessible only to specific NFT holders, enhancing user engagement and value on the platform.
 """
 type ContentSpace implements Entity & Node {
+  contentSpaceParameters: contentSpaceParameters
+
   """The time the document was created"""
   createdAt(
     """
@@ -2071,6 +2073,11 @@ input ContentSpaceWhereStageInput {
 """References ContentSpace record uniquely"""
 input ContentSpaceWhereUniqueInput {
   id: ID
+  slug: String
+}
+
+"""References ContentSpace record uniquely"""
+input ContentSpaceWhereUniqueInput_remote_rel_contentSpaceParameterscontentSpace {
   slug: String
 }
 
@@ -10462,6 +10469,403 @@ input bigint_comparison_exp {
 }
 
 """
+The contentSpaceParameters model is designed to define properties specifically for content spaces. This table includes essential details like the contentSpaceId, which links to the specific content space. By centralizing this information, our system can effectively manage and control parameters tied to each content space, enhancing functionality and flexibility.
+"""
+type contentSpaceParameters {
+  contentSpace(
+    """
+    Defines which locales should be returned.
+    
+    Note that `ContentSpace` will be affected directly by this argument, as well as any other related models with localized fields in the query's subtree.
+    The first locale matching the provided list will be returned, entries with non matching locales will be filtered out.
+    
+    This argument may be overwritten by another locales definition in a relational child field, this will effectively use the overwritten argument for the affected query's subtree.
+    """
+    locales: [Locale!]! = [en]
+    stage: Stage! = PUBLISHED
+    where: ContentSpaceWhereUniqueInput_remote_rel_contentSpaceParameterscontentSpace!
+  ): ContentSpace
+
+  """
+  It stores the identifier for the content space. This ID is crucial for managing and linking specific parameters to each content space, ensuring accurate and efficient handling of content space-related data.
+  """
+  contentSpaceId: String!
+  created_at: timestamptz!
+  id: uuid!
+  organizerId: String!
+  status: contentSpaceStatus_enum
+  updated_at: timestamptz!
+}
+
+"""
+aggregated selection of "contentSpaceParameters"
+"""
+type contentSpaceParameters_aggregate {
+  aggregate: contentSpaceParameters_aggregate_fields
+  nodes: [contentSpaceParameters!]!
+}
+
+"""
+aggregate fields of "contentSpaceParameters"
+"""
+type contentSpaceParameters_aggregate_fields {
+  count(columns: [contentSpaceParameters_select_column!], distinct: Boolean): Int!
+  max: contentSpaceParameters_max_fields
+  min: contentSpaceParameters_min_fields
+}
+
+"""
+Boolean expression to filter rows from the table "contentSpaceParameters". All fields are combined with a logical 'AND'.
+"""
+input contentSpaceParameters_bool_exp {
+  _and: [contentSpaceParameters_bool_exp!]
+  _not: contentSpaceParameters_bool_exp
+  _or: [contentSpaceParameters_bool_exp!]
+  contentSpaceId: String_comparison_exp
+  created_at: timestamptz_comparison_exp
+  id: uuid_comparison_exp
+  organizerId: String_comparison_exp
+  status: contentSpaceStatus_enum_comparison_exp
+  updated_at: timestamptz_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "contentSpaceParameters"
+"""
+enum contentSpaceParameters_constraint {
+  """
+  unique or primary key constraint on columns "contentSpaceId"
+  """
+  contentSpaceParameters_contentSpaceId_key
+
+  """
+  unique or primary key constraint on columns "id"
+  """
+  contentSpaceParameters_pkey
+}
+
+"""
+input type for inserting data into table "contentSpaceParameters"
+"""
+input contentSpaceParameters_insert_input {
+  """
+  It stores the identifier for the content space. This ID is crucial for managing and linking specific parameters to each content space, ensuring accurate and efficient handling of content space-related data.
+  """
+  contentSpaceId: String
+  created_at: timestamptz
+  id: uuid
+  organizerId: String
+  status: contentSpaceStatus_enum
+  updated_at: timestamptz
+}
+
+"""aggregate max on columns"""
+type contentSpaceParameters_max_fields {
+  """
+  It stores the identifier for the content space. This ID is crucial for managing and linking specific parameters to each content space, ensuring accurate and efficient handling of content space-related data.
+  """
+  contentSpaceId: String
+  created_at: timestamptz
+  id: uuid
+  organizerId: String
+  updated_at: timestamptz
+}
+
+"""aggregate min on columns"""
+type contentSpaceParameters_min_fields {
+  """
+  It stores the identifier for the content space. This ID is crucial for managing and linking specific parameters to each content space, ensuring accurate and efficient handling of content space-related data.
+  """
+  contentSpaceId: String
+  created_at: timestamptz
+  id: uuid
+  organizerId: String
+  updated_at: timestamptz
+}
+
+"""
+response of any mutation on the table "contentSpaceParameters"
+"""
+type contentSpaceParameters_mutation_response {
+  """number of rows affected by the mutation"""
+  affected_rows: Int!
+
+  """data from the rows affected by the mutation"""
+  returning: [contentSpaceParameters!]!
+}
+
+"""
+on_conflict condition type for table "contentSpaceParameters"
+"""
+input contentSpaceParameters_on_conflict {
+  constraint: contentSpaceParameters_constraint!
+  update_columns: [contentSpaceParameters_update_column!]! = []
+  where: contentSpaceParameters_bool_exp
+}
+
+"""Ordering options when selecting data from "contentSpaceParameters"."""
+input contentSpaceParameters_order_by {
+  contentSpaceId: order_by
+  created_at: order_by
+  id: order_by
+  organizerId: order_by
+  status: order_by
+  updated_at: order_by
+}
+
+"""primary key columns input for table: contentSpaceParameters"""
+input contentSpaceParameters_pk_columns_input {
+  id: uuid!
+}
+
+"""
+select columns of table "contentSpaceParameters"
+"""
+enum contentSpaceParameters_select_column {
+  """column name"""
+  contentSpaceId
+
+  """column name"""
+  created_at
+
+  """column name"""
+  id
+
+  """column name"""
+  organizerId
+
+  """column name"""
+  status
+
+  """column name"""
+  updated_at
+}
+
+"""
+input type for updating data in table "contentSpaceParameters"
+"""
+input contentSpaceParameters_set_input {
+  """
+  It stores the identifier for the content space. This ID is crucial for managing and linking specific parameters to each content space, ensuring accurate and efficient handling of content space-related data.
+  """
+  contentSpaceId: String
+  created_at: timestamptz
+  id: uuid
+  organizerId: String
+  status: contentSpaceStatus_enum
+  updated_at: timestamptz
+}
+
+"""
+Streaming cursor of the table "contentSpaceParameters"
+"""
+input contentSpaceParameters_stream_cursor_input {
+  """Stream column input with initial value"""
+  initial_value: contentSpaceParameters_stream_cursor_value_input!
+
+  """cursor ordering"""
+  ordering: cursor_ordering
+}
+
+"""Initial value of the column from where the streaming should start"""
+input contentSpaceParameters_stream_cursor_value_input {
+  """
+  It stores the identifier for the content space. This ID is crucial for managing and linking specific parameters to each content space, ensuring accurate and efficient handling of content space-related data.
+  """
+  contentSpaceId: String
+  created_at: timestamptz
+  id: uuid
+  organizerId: String
+  status: contentSpaceStatus_enum
+  updated_at: timestamptz
+}
+
+"""
+update columns of table "contentSpaceParameters"
+"""
+enum contentSpaceParameters_update_column {
+  """column name"""
+  contentSpaceId
+
+  """column name"""
+  created_at
+
+  """column name"""
+  id
+
+  """column name"""
+  organizerId
+
+  """column name"""
+  status
+
+  """column name"""
+  updated_at
+}
+
+input contentSpaceParameters_updates {
+  """sets the columns of the filtered rows to the given values"""
+  _set: contentSpaceParameters_set_input
+
+  """filter the rows which have to be updated"""
+  where: contentSpaceParameters_bool_exp!
+}
+
+"""
+columns and relationships of "contentSpaceStatus"
+"""
+type contentSpaceStatus {
+  value: String!
+}
+
+"""
+aggregated selection of "contentSpaceStatus"
+"""
+type contentSpaceStatus_aggregate {
+  aggregate: contentSpaceStatus_aggregate_fields
+  nodes: [contentSpaceStatus!]!
+}
+
+"""
+aggregate fields of "contentSpaceStatus"
+"""
+type contentSpaceStatus_aggregate_fields {
+  count(columns: [contentSpaceStatus_select_column!], distinct: Boolean): Int!
+  max: contentSpaceStatus_max_fields
+  min: contentSpaceStatus_min_fields
+}
+
+"""
+Boolean expression to filter rows from the table "contentSpaceStatus". All fields are combined with a logical 'AND'.
+"""
+input contentSpaceStatus_bool_exp {
+  _and: [contentSpaceStatus_bool_exp!]
+  _not: contentSpaceStatus_bool_exp
+  _or: [contentSpaceStatus_bool_exp!]
+  value: String_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "contentSpaceStatus"
+"""
+enum contentSpaceStatus_constraint {
+  """
+  unique or primary key constraint on columns "value"
+  """
+  contentSpaceStatus_pkey
+}
+
+enum contentSpaceStatus_enum {
+  DRAFT
+  PUBLISHED
+}
+
+"""
+Boolean expression to compare columns of type "contentSpaceStatus_enum". All fields are combined with logical 'AND'.
+"""
+input contentSpaceStatus_enum_comparison_exp {
+  _eq: contentSpaceStatus_enum
+  _in: [contentSpaceStatus_enum!]
+  _is_null: Boolean
+  _neq: contentSpaceStatus_enum
+  _nin: [contentSpaceStatus_enum!]
+}
+
+"""
+input type for inserting data into table "contentSpaceStatus"
+"""
+input contentSpaceStatus_insert_input {
+  value: String
+}
+
+"""aggregate max on columns"""
+type contentSpaceStatus_max_fields {
+  value: String
+}
+
+"""aggregate min on columns"""
+type contentSpaceStatus_min_fields {
+  value: String
+}
+
+"""
+response of any mutation on the table "contentSpaceStatus"
+"""
+type contentSpaceStatus_mutation_response {
+  """number of rows affected by the mutation"""
+  affected_rows: Int!
+
+  """data from the rows affected by the mutation"""
+  returning: [contentSpaceStatus!]!
+}
+
+"""
+on_conflict condition type for table "contentSpaceStatus"
+"""
+input contentSpaceStatus_on_conflict {
+  constraint: contentSpaceStatus_constraint!
+  update_columns: [contentSpaceStatus_update_column!]! = []
+  where: contentSpaceStatus_bool_exp
+}
+
+"""Ordering options when selecting data from "contentSpaceStatus"."""
+input contentSpaceStatus_order_by {
+  value: order_by
+}
+
+"""primary key columns input for table: contentSpaceStatus"""
+input contentSpaceStatus_pk_columns_input {
+  value: String!
+}
+
+"""
+select columns of table "contentSpaceStatus"
+"""
+enum contentSpaceStatus_select_column {
+  """column name"""
+  value
+}
+
+"""
+input type for updating data in table "contentSpaceStatus"
+"""
+input contentSpaceStatus_set_input {
+  value: String
+}
+
+"""
+Streaming cursor of the table "contentSpaceStatus"
+"""
+input contentSpaceStatus_stream_cursor_input {
+  """Stream column input with initial value"""
+  initial_value: contentSpaceStatus_stream_cursor_value_input!
+
+  """cursor ordering"""
+  ordering: cursor_ordering
+}
+
+"""Initial value of the column from where the streaming should start"""
+input contentSpaceStatus_stream_cursor_value_input {
+  value: String
+}
+
+"""
+update columns of table "contentSpaceStatus"
+"""
+enum contentSpaceStatus_update_column {
+  """column name"""
+  value
+}
+
+input contentSpaceStatus_updates {
+  """sets the columns of the filtered rows to the given values"""
+  _set: contentSpaceStatus_set_input
+
+  """filter the rows which have to be updated"""
+  where: contentSpaceStatus_bool_exp!
+}
+
+"""
 Currencies code following the standard ISO 4217 (https://en.wikipedia.org/wiki/ISO_4217)
 """
 type currency {
@@ -15572,6 +15976,32 @@ type mutation_root {
   delete_account_by_pk(id: uuid!): account
 
   """
+  delete data from the table: "contentSpaceParameters"
+  """
+  delete_contentSpaceParameters(
+    """filter the rows which have to be deleted"""
+    where: contentSpaceParameters_bool_exp!
+  ): contentSpaceParameters_mutation_response
+
+  """
+  delete single row from the table: "contentSpaceParameters"
+  """
+  delete_contentSpaceParameters_by_pk(id: uuid!): contentSpaceParameters
+
+  """
+  delete data from the table: "contentSpaceStatus"
+  """
+  delete_contentSpaceStatus(
+    """filter the rows which have to be deleted"""
+    where: contentSpaceStatus_bool_exp!
+  ): contentSpaceStatus_mutation_response
+
+  """
+  delete single row from the table: "contentSpaceStatus"
+  """
+  delete_contentSpaceStatus_by_pk(value: String!): contentSpaceStatus
+
+  """
   delete data from the table: "currency"
   """
   delete_currency(
@@ -16072,6 +16502,50 @@ type mutation_root {
     """upsert condition"""
     on_conflict: account_on_conflict
   ): account
+
+  """
+  insert data into the table: "contentSpaceParameters"
+  """
+  insert_contentSpaceParameters(
+    """the rows to be inserted"""
+    objects: [contentSpaceParameters_insert_input!]!
+
+    """upsert condition"""
+    on_conflict: contentSpaceParameters_on_conflict
+  ): contentSpaceParameters_mutation_response
+
+  """
+  insert a single row into the table: "contentSpaceParameters"
+  """
+  insert_contentSpaceParameters_one(
+    """the row to be inserted"""
+    object: contentSpaceParameters_insert_input!
+
+    """upsert condition"""
+    on_conflict: contentSpaceParameters_on_conflict
+  ): contentSpaceParameters
+
+  """
+  insert data into the table: "contentSpaceStatus"
+  """
+  insert_contentSpaceStatus(
+    """the rows to be inserted"""
+    objects: [contentSpaceStatus_insert_input!]!
+
+    """upsert condition"""
+    on_conflict: contentSpaceStatus_on_conflict
+  ): contentSpaceStatus_mutation_response
+
+  """
+  insert a single row into the table: "contentSpaceStatus"
+  """
+  insert_contentSpaceStatus_one(
+    """the row to be inserted"""
+    object: contentSpaceStatus_insert_input!
+
+    """upsert condition"""
+    on_conflict: contentSpaceStatus_on_conflict
+  ): contentSpaceStatus
 
   """
   insert data into the table: "currency"
@@ -18256,6 +18730,62 @@ type mutation_root {
     """updates to execute, in order"""
     updates: [account_updates!]!
   ): [account_mutation_response]
+
+  """
+  update data of the table: "contentSpaceParameters"
+  """
+  update_contentSpaceParameters(
+    """sets the columns of the filtered rows to the given values"""
+    _set: contentSpaceParameters_set_input
+
+    """filter the rows which have to be updated"""
+    where: contentSpaceParameters_bool_exp!
+  ): contentSpaceParameters_mutation_response
+
+  """
+  update single row of the table: "contentSpaceParameters"
+  """
+  update_contentSpaceParameters_by_pk(
+    """sets the columns of the filtered rows to the given values"""
+    _set: contentSpaceParameters_set_input
+    pk_columns: contentSpaceParameters_pk_columns_input!
+  ): contentSpaceParameters
+
+  """
+  update multiples rows of table: "contentSpaceParameters"
+  """
+  update_contentSpaceParameters_many(
+    """updates to execute, in order"""
+    updates: [contentSpaceParameters_updates!]!
+  ): [contentSpaceParameters_mutation_response]
+
+  """
+  update data of the table: "contentSpaceStatus"
+  """
+  update_contentSpaceStatus(
+    """sets the columns of the filtered rows to the given values"""
+    _set: contentSpaceStatus_set_input
+
+    """filter the rows which have to be updated"""
+    where: contentSpaceStatus_bool_exp!
+  ): contentSpaceStatus_mutation_response
+
+  """
+  update single row of the table: "contentSpaceStatus"
+  """
+  update_contentSpaceStatus_by_pk(
+    """sets the columns of the filtered rows to the given values"""
+    _set: contentSpaceStatus_set_input
+    pk_columns: contentSpaceStatus_pk_columns_input!
+  ): contentSpaceStatus
+
+  """
+  update multiples rows of table: "contentSpaceStatus"
+  """
+  update_contentSpaceStatus_many(
+    """updates to execute, in order"""
+    updates: [contentSpaceStatus_updates!]!
+  ): [contentSpaceStatus_mutation_response]
 
   """
   update data of the table: "currency"
@@ -24030,6 +24560,96 @@ type query_root {
     where: ContentSpaceWhereUniqueInput!
   ): ContentSpace
 
+  """
+  fetch data from the table: "contentSpaceParameters"
+  """
+  contentSpaceParameters(
+    """distinct select on columns"""
+    distinct_on: [contentSpaceParameters_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [contentSpaceParameters_order_by!]
+
+    """filter the rows returned"""
+    where: contentSpaceParameters_bool_exp
+  ): [contentSpaceParameters!]!
+
+  """
+  fetch aggregated fields from the table: "contentSpaceParameters"
+  """
+  contentSpaceParameters_aggregate(
+    """distinct select on columns"""
+    distinct_on: [contentSpaceParameters_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [contentSpaceParameters_order_by!]
+
+    """filter the rows returned"""
+    where: contentSpaceParameters_bool_exp
+  ): contentSpaceParameters_aggregate!
+
+  """
+  fetch data from the table: "contentSpaceParameters" using primary key columns
+  """
+  contentSpaceParameters_by_pk(id: uuid!): contentSpaceParameters
+
+  """
+  fetch data from the table: "contentSpaceStatus"
+  """
+  contentSpaceStatus(
+    """distinct select on columns"""
+    distinct_on: [contentSpaceStatus_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [contentSpaceStatus_order_by!]
+
+    """filter the rows returned"""
+    where: contentSpaceStatus_bool_exp
+  ): [contentSpaceStatus!]!
+
+  """
+  fetch aggregated fields from the table: "contentSpaceStatus"
+  """
+  contentSpaceStatus_aggregate(
+    """distinct select on columns"""
+    distinct_on: [contentSpaceStatus_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [contentSpaceStatus_order_by!]
+
+    """filter the rows returned"""
+    where: contentSpaceStatus_bool_exp
+  ): contentSpaceStatus_aggregate!
+
+  """
+  fetch data from the table: "contentSpaceStatus" using primary key columns
+  """
+  contentSpaceStatus_by_pk(value: String!): contentSpaceStatus
+
   """Retrieve document version"""
   contentSpaceVersion(where: VersionWhereInput!): DocumentVersion
 
@@ -27209,6 +27829,124 @@ type subscription_root {
     """filter the rows returned"""
     where: account_bool_exp
   ): [account!]!
+
+  """
+  fetch data from the table: "contentSpaceParameters"
+  """
+  contentSpaceParameters(
+    """distinct select on columns"""
+    distinct_on: [contentSpaceParameters_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [contentSpaceParameters_order_by!]
+
+    """filter the rows returned"""
+    where: contentSpaceParameters_bool_exp
+  ): [contentSpaceParameters!]!
+
+  """
+  fetch aggregated fields from the table: "contentSpaceParameters"
+  """
+  contentSpaceParameters_aggregate(
+    """distinct select on columns"""
+    distinct_on: [contentSpaceParameters_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [contentSpaceParameters_order_by!]
+
+    """filter the rows returned"""
+    where: contentSpaceParameters_bool_exp
+  ): contentSpaceParameters_aggregate!
+
+  """
+  fetch data from the table: "contentSpaceParameters" using primary key columns
+  """
+  contentSpaceParameters_by_pk(id: uuid!): contentSpaceParameters
+
+  """
+  fetch data from the table in a streaming manner: "contentSpaceParameters"
+  """
+  contentSpaceParameters_stream(
+    """maximum number of rows returned in a single batch"""
+    batch_size: Int!
+
+    """cursor to stream the results returned by the query"""
+    cursor: [contentSpaceParameters_stream_cursor_input]!
+
+    """filter the rows returned"""
+    where: contentSpaceParameters_bool_exp
+  ): [contentSpaceParameters!]!
+
+  """
+  fetch data from the table: "contentSpaceStatus"
+  """
+  contentSpaceStatus(
+    """distinct select on columns"""
+    distinct_on: [contentSpaceStatus_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [contentSpaceStatus_order_by!]
+
+    """filter the rows returned"""
+    where: contentSpaceStatus_bool_exp
+  ): [contentSpaceStatus!]!
+
+  """
+  fetch aggregated fields from the table: "contentSpaceStatus"
+  """
+  contentSpaceStatus_aggregate(
+    """distinct select on columns"""
+    distinct_on: [contentSpaceStatus_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [contentSpaceStatus_order_by!]
+
+    """filter the rows returned"""
+    where: contentSpaceStatus_bool_exp
+  ): contentSpaceStatus_aggregate!
+
+  """
+  fetch data from the table: "contentSpaceStatus" using primary key columns
+  """
+  contentSpaceStatus_by_pk(value: String!): contentSpaceStatus
+
+  """
+  fetch data from the table in a streaming manner: "contentSpaceStatus"
+  """
+  contentSpaceStatus_stream(
+    """maximum number of rows returned in a single batch"""
+    batch_size: Int!
+
+    """cursor to stream the results returned by the query"""
+    cursor: [contentSpaceStatus_stream_cursor_input]!
+
+    """filter the rows returned"""
+    where: contentSpaceStatus_bool_exp
+  ): [contentSpaceStatus!]!
 
   """
   fetch data from the table: "currency"

--- a/libs/gql/admin/api/src/queries/organizer/contentSpace/ContentSpaceFields.fragment.gql
+++ b/libs/gql/admin/api/src/queries/organizer/contentSpace/ContentSpaceFields.fragment.gql
@@ -1,0 +1,18 @@
+fragment ContentSpaceFields on ContentSpace {
+  title
+  slug
+  heroImage {
+    url
+  }
+  description {
+    json
+    references {
+      ... on Asset {
+        __typename
+        id
+        url
+        mimeType
+      }
+    }
+  }
+}

--- a/libs/gql/admin/api/src/queries/organizer/contentSpace/contentSpace.query.gql
+++ b/libs/gql/admin/api/src/queries/organizer/contentSpace/contentSpace.query.gql
@@ -1,0 +1,42 @@
+query GetContentSpaceFromOrganizerIdTable(
+  $id: ID!
+  $locale: Locale!
+  $stage: Stage!
+) @cached {
+  organizer(where: { id: $id }, locales: [$locale, en], stage: $stage) {
+    contentSpaces {
+      slug
+      title
+      contentSpaceParameters {
+        status
+      }
+    }
+  }
+}
+
+query GetContentSpaceWithEventPassesOrganizer(
+  $slug: String!
+  $locale: Locale!
+  $stage: Stage!
+) @cached {
+  contentSpace(where: { slug: $slug }, locales: [$locale, en], stage: $stage) {
+    title
+    slug
+    heroImage {
+      url
+    }
+    contentSpaceParameters {
+      status
+    }
+    eventPasses(forceParentLocale: true) {
+      ... on EventPass {
+        id
+        name
+        event {
+          slug
+          title
+        }
+      }
+    }
+  }
+}

--- a/libs/gql/admin/api/src/queries/organizer/contentSpace/contentSpaceParameters.mutation.gql
+++ b/libs/gql/admin/api/src/queries/organizer/contentSpace/contentSpaceParameters.mutation.gql
@@ -1,0 +1,7 @@
+mutation CreateContentSpaceParameters(
+  $object: contentSpaceParameters_insert_input!
+) {
+  insert_contentSpaceParameters_one(object: $object) {
+    id
+  }
+}

--- a/libs/gql/admin/api/src/queries/organizer/event/eventParameters.query.gql
+++ b/libs/gql/admin/api/src/queries/organizer/event/eventParameters.query.gql
@@ -23,6 +23,7 @@ query GetEventParameters($eventId: String) {
   }
 }
 
+# Is stage: DRAFT causing an issue on production ?
 query GetEventParametersFromEventPassIds($eventPassIds: [ID!]!) {
   eventPasses(where: { id_in: $eventPassIds }, stage: DRAFT, locales: [en]) {
     id

--- a/libs/gql/admin/types/src/generated/index.ts
+++ b/libs/gql/admin/types/src/generated/index.ts
@@ -155,6 +155,33 @@ export type GetNftTransferByTokenIdAndCollectionQuery = { __typename?: 'query_ro
 
 export type OrganizerFieldsFragment = { __typename?: 'Organizer', id: string, slug: string, name: string, imageClasses?: string | null, image: { __typename?: 'Asset', url: string } };
 
+export type ContentSpaceFieldsFragment = { __typename?: 'ContentSpace', title: string, slug?: string | null, heroImage: { __typename?: 'Asset', url: string }, description: { __typename?: 'ContentSpaceDescriptionRichText', json: any, references: Array<{ __typename: 'Asset', id: string, url: string, mimeType?: string | null }> } };
+
+export type GetContentSpaceFromOrganizerIdTableQueryVariables = Types.Exact<{
+  id: Types.Scalars['ID']['input'];
+  locale: Types.Locale;
+  stage: Types.Stage;
+}>;
+
+
+export type GetContentSpaceFromOrganizerIdTableQuery = { __typename?: 'query_root', organizer?: { __typename?: 'Organizer', contentSpaces: Array<{ __typename?: 'ContentSpace', slug?: string | null, title: string, contentSpaceParameters?: { __typename?: 'contentSpaceParameters', status?: Types.ContentSpaceStatus_Enum | null } | null }> } | null };
+
+export type GetContentSpaceWithEventPassesOrganizerQueryVariables = Types.Exact<{
+  slug: Types.Scalars['String']['input'];
+  locale: Types.Locale;
+  stage: Types.Stage;
+}>;
+
+
+export type GetContentSpaceWithEventPassesOrganizerQuery = { __typename?: 'query_root', contentSpace?: { __typename?: 'ContentSpace', title: string, slug?: string | null, heroImage: { __typename?: 'Asset', url: string }, contentSpaceParameters?: { __typename?: 'contentSpaceParameters', status?: Types.ContentSpaceStatus_Enum | null } | null, eventPasses: Array<{ __typename?: 'EventPass', id: string, name: string, event?: { __typename?: 'Event', slug: string, title: string } | null }> } | null };
+
+export type CreateContentSpaceParametersMutationVariables = Types.Exact<{
+  object: Types.ContentSpaceParameters_Insert_Input;
+}>;
+
+
+export type CreateContentSpaceParametersMutation = { __typename?: 'mutation_root', insert_contentSpaceParameters_one?: { __typename?: 'contentSpaceParameters', id: any } | null };
+
 export type EventDateLocationsFieldsFragment = { __typename?: 'EventDateLocation', dateStart: any, dateEnd: any, locationAddress: { __typename?: 'LocationAddress', city: string, country: string, placeId?: string | null, postalCode: string, state?: string | null, street?: string | null, venue?: string | null, coordinates: { __typename?: 'Location', latitude: number, longitude: number } } };
 
 export type EventListFieldsFragment = { __typename?: 'Event', id: string, slug: string, title: string, heroImageClasses?: string | null, heroImage: { __typename?: 'Asset', width?: number | null, height?: number | null, url: string } };

--- a/libs/gql/shared/types/src/generated/index.ts
+++ b/libs/gql/shared/types/src/generated/index.ts
@@ -841,6 +841,7 @@ export type ConnectPositionInput = {
 /** The ContentSpace model is a core component in delivering exclusive, NFT-linked digital content. It serves as a hub for organizers to manage and distribute unique content accessible only to specific NFT holders, enhancing user engagement and value on the platform. */
 export type ContentSpace = Entity & Node & {
   __typename?: 'ContentSpace';
+  contentSpaceParameters?: Maybe<ContentSpaceParameters>;
   /** The time the document was created */
   createdAt: Scalars['DateTime']['output'];
   /** User that created this document */
@@ -1505,6 +1506,11 @@ export type ContentSpaceWhereStageInput = {
 /** References ContentSpace record uniquely */
 export type ContentSpaceWhereUniqueInput = {
   id?: InputMaybe<Scalars['ID']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** References ContentSpace record uniquely */
+export type ContentSpaceWhereUniqueInput_Remote_Rel_ContentSpaceParameterscontentSpace = {
   slug?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -7507,6 +7513,339 @@ export type Bigint_Comparison_Exp = {
   _nin?: InputMaybe<Array<Scalars['bigint']['input']>>;
 };
 
+/** The contentSpaceParameters model is designed to define properties specifically for content spaces. This table includes essential details like the contentSpaceId, which links to the specific content space. By centralizing this information, our system can effectively manage and control parameters tied to each content space, enhancing functionality and flexibility. */
+export type ContentSpaceParameters = {
+  __typename?: 'contentSpaceParameters';
+  contentSpace?: Maybe<ContentSpace>;
+  /** It stores the identifier for the content space. This ID is crucial for managing and linking specific parameters to each content space, ensuring accurate and efficient handling of content space-related data. */
+  contentSpaceId: Scalars['String']['output'];
+  created_at: Scalars['timestamptz']['output'];
+  id: Scalars['uuid']['output'];
+  organizerId: Scalars['String']['output'];
+  status?: Maybe<ContentSpaceStatus_Enum>;
+  updated_at: Scalars['timestamptz']['output'];
+};
+
+
+/** The contentSpaceParameters model is designed to define properties specifically for content spaces. This table includes essential details like the contentSpaceId, which links to the specific content space. By centralizing this information, our system can effectively manage and control parameters tied to each content space, enhancing functionality and flexibility. */
+export type ContentSpaceParametersContentSpaceArgs = {
+  locales?: Array<Locale>;
+  stage?: Stage;
+  where: ContentSpaceWhereUniqueInput_Remote_Rel_ContentSpaceParameterscontentSpace;
+};
+
+/** aggregated selection of "contentSpaceParameters" */
+export type ContentSpaceParameters_Aggregate = {
+  __typename?: 'contentSpaceParameters_aggregate';
+  aggregate?: Maybe<ContentSpaceParameters_Aggregate_Fields>;
+  nodes: Array<ContentSpaceParameters>;
+};
+
+/** aggregate fields of "contentSpaceParameters" */
+export type ContentSpaceParameters_Aggregate_Fields = {
+  __typename?: 'contentSpaceParameters_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<ContentSpaceParameters_Max_Fields>;
+  min?: Maybe<ContentSpaceParameters_Min_Fields>;
+};
+
+
+/** aggregate fields of "contentSpaceParameters" */
+export type ContentSpaceParameters_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<ContentSpaceParameters_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "contentSpaceParameters". All fields are combined with a logical 'AND'. */
+export type ContentSpaceParameters_Bool_Exp = {
+  _and?: InputMaybe<Array<ContentSpaceParameters_Bool_Exp>>;
+  _not?: InputMaybe<ContentSpaceParameters_Bool_Exp>;
+  _or?: InputMaybe<Array<ContentSpaceParameters_Bool_Exp>>;
+  contentSpaceId?: InputMaybe<String_Comparison_Exp>;
+  created_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+  id?: InputMaybe<Uuid_Comparison_Exp>;
+  organizerId?: InputMaybe<String_Comparison_Exp>;
+  status?: InputMaybe<ContentSpaceStatus_Enum_Comparison_Exp>;
+  updated_at?: InputMaybe<Timestamptz_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "contentSpaceParameters" */
+export const enum ContentSpaceParameters_Constraint {
+  /** unique or primary key constraint on columns "contentSpaceId" */
+  ContentSpaceParametersContentSpaceIdKey = 'contentSpaceParameters_contentSpaceId_key',
+  /** unique or primary key constraint on columns "id" */
+  ContentSpaceParametersPkey = 'contentSpaceParameters_pkey'
+};
+
+/** input type for inserting data into table "contentSpaceParameters" */
+export type ContentSpaceParameters_Insert_Input = {
+  /** It stores the identifier for the content space. This ID is crucial for managing and linking specific parameters to each content space, ensuring accurate and efficient handling of content space-related data. */
+  contentSpaceId?: InputMaybe<Scalars['String']['input']>;
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  id?: InputMaybe<Scalars['uuid']['input']>;
+  organizerId?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<ContentSpaceStatus_Enum>;
+  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** aggregate max on columns */
+export type ContentSpaceParameters_Max_Fields = {
+  __typename?: 'contentSpaceParameters_max_fields';
+  /** It stores the identifier for the content space. This ID is crucial for managing and linking specific parameters to each content space, ensuring accurate and efficient handling of content space-related data. */
+  contentSpaceId?: Maybe<Scalars['String']['output']>;
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  id?: Maybe<Scalars['uuid']['output']>;
+  organizerId?: Maybe<Scalars['String']['output']>;
+  updated_at?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+/** aggregate min on columns */
+export type ContentSpaceParameters_Min_Fields = {
+  __typename?: 'contentSpaceParameters_min_fields';
+  /** It stores the identifier for the content space. This ID is crucial for managing and linking specific parameters to each content space, ensuring accurate and efficient handling of content space-related data. */
+  contentSpaceId?: Maybe<Scalars['String']['output']>;
+  created_at?: Maybe<Scalars['timestamptz']['output']>;
+  id?: Maybe<Scalars['uuid']['output']>;
+  organizerId?: Maybe<Scalars['String']['output']>;
+  updated_at?: Maybe<Scalars['timestamptz']['output']>;
+};
+
+/** response of any mutation on the table "contentSpaceParameters" */
+export type ContentSpaceParameters_Mutation_Response = {
+  __typename?: 'contentSpaceParameters_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int']['output'];
+  /** data from the rows affected by the mutation */
+  returning: Array<ContentSpaceParameters>;
+};
+
+/** on_conflict condition type for table "contentSpaceParameters" */
+export type ContentSpaceParameters_On_Conflict = {
+  constraint: ContentSpaceParameters_Constraint;
+  update_columns?: Array<ContentSpaceParameters_Update_Column>;
+  where?: InputMaybe<ContentSpaceParameters_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "contentSpaceParameters". */
+export type ContentSpaceParameters_Order_By = {
+  contentSpaceId?: InputMaybe<Order_By>;
+  created_at?: InputMaybe<Order_By>;
+  id?: InputMaybe<Order_By>;
+  organizerId?: InputMaybe<Order_By>;
+  status?: InputMaybe<Order_By>;
+  updated_at?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: contentSpaceParameters */
+export type ContentSpaceParameters_Pk_Columns_Input = {
+  id: Scalars['uuid']['input'];
+};
+
+/** select columns of table "contentSpaceParameters" */
+export const enum ContentSpaceParameters_Select_Column {
+  /** column name */
+  ContentSpaceId = 'contentSpaceId',
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  Id = 'id',
+  /** column name */
+  OrganizerId = 'organizerId',
+  /** column name */
+  Status = 'status',
+  /** column name */
+  UpdatedAt = 'updated_at'
+};
+
+/** input type for updating data in table "contentSpaceParameters" */
+export type ContentSpaceParameters_Set_Input = {
+  /** It stores the identifier for the content space. This ID is crucial for managing and linking specific parameters to each content space, ensuring accurate and efficient handling of content space-related data. */
+  contentSpaceId?: InputMaybe<Scalars['String']['input']>;
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  id?: InputMaybe<Scalars['uuid']['input']>;
+  organizerId?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<ContentSpaceStatus_Enum>;
+  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** Streaming cursor of the table "contentSpaceParameters" */
+export type ContentSpaceParameters_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: ContentSpaceParameters_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type ContentSpaceParameters_Stream_Cursor_Value_Input = {
+  /** It stores the identifier for the content space. This ID is crucial for managing and linking specific parameters to each content space, ensuring accurate and efficient handling of content space-related data. */
+  contentSpaceId?: InputMaybe<Scalars['String']['input']>;
+  created_at?: InputMaybe<Scalars['timestamptz']['input']>;
+  id?: InputMaybe<Scalars['uuid']['input']>;
+  organizerId?: InputMaybe<Scalars['String']['input']>;
+  status?: InputMaybe<ContentSpaceStatus_Enum>;
+  updated_at?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+/** update columns of table "contentSpaceParameters" */
+export const enum ContentSpaceParameters_Update_Column {
+  /** column name */
+  ContentSpaceId = 'contentSpaceId',
+  /** column name */
+  CreatedAt = 'created_at',
+  /** column name */
+  Id = 'id',
+  /** column name */
+  OrganizerId = 'organizerId',
+  /** column name */
+  Status = 'status',
+  /** column name */
+  UpdatedAt = 'updated_at'
+};
+
+export type ContentSpaceParameters_Updates = {
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<ContentSpaceParameters_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: ContentSpaceParameters_Bool_Exp;
+};
+
+/** columns and relationships of "contentSpaceStatus" */
+export type ContentSpaceStatus = {
+  __typename?: 'contentSpaceStatus';
+  value: Scalars['String']['output'];
+};
+
+/** aggregated selection of "contentSpaceStatus" */
+export type ContentSpaceStatus_Aggregate = {
+  __typename?: 'contentSpaceStatus_aggregate';
+  aggregate?: Maybe<ContentSpaceStatus_Aggregate_Fields>;
+  nodes: Array<ContentSpaceStatus>;
+};
+
+/** aggregate fields of "contentSpaceStatus" */
+export type ContentSpaceStatus_Aggregate_Fields = {
+  __typename?: 'contentSpaceStatus_aggregate_fields';
+  count: Scalars['Int']['output'];
+  max?: Maybe<ContentSpaceStatus_Max_Fields>;
+  min?: Maybe<ContentSpaceStatus_Min_Fields>;
+};
+
+
+/** aggregate fields of "contentSpaceStatus" */
+export type ContentSpaceStatus_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<ContentSpaceStatus_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** Boolean expression to filter rows from the table "contentSpaceStatus". All fields are combined with a logical 'AND'. */
+export type ContentSpaceStatus_Bool_Exp = {
+  _and?: InputMaybe<Array<ContentSpaceStatus_Bool_Exp>>;
+  _not?: InputMaybe<ContentSpaceStatus_Bool_Exp>;
+  _or?: InputMaybe<Array<ContentSpaceStatus_Bool_Exp>>;
+  value?: InputMaybe<String_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "contentSpaceStatus" */
+export const enum ContentSpaceStatus_Constraint {
+  /** unique or primary key constraint on columns "value" */
+  ContentSpaceStatusPkey = 'contentSpaceStatus_pkey'
+};
+
+export const enum ContentSpaceStatus_Enum {
+  Draft = 'DRAFT',
+  Published = 'PUBLISHED'
+};
+
+/** Boolean expression to compare columns of type "contentSpaceStatus_enum". All fields are combined with logical 'AND'. */
+export type ContentSpaceStatus_Enum_Comparison_Exp = {
+  _eq?: InputMaybe<ContentSpaceStatus_Enum>;
+  _in?: InputMaybe<Array<ContentSpaceStatus_Enum>>;
+  _is_null?: InputMaybe<Scalars['Boolean']['input']>;
+  _neq?: InputMaybe<ContentSpaceStatus_Enum>;
+  _nin?: InputMaybe<Array<ContentSpaceStatus_Enum>>;
+};
+
+/** input type for inserting data into table "contentSpaceStatus" */
+export type ContentSpaceStatus_Insert_Input = {
+  value?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregate max on columns */
+export type ContentSpaceStatus_Max_Fields = {
+  __typename?: 'contentSpaceStatus_max_fields';
+  value?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type ContentSpaceStatus_Min_Fields = {
+  __typename?: 'contentSpaceStatus_min_fields';
+  value?: Maybe<Scalars['String']['output']>;
+};
+
+/** response of any mutation on the table "contentSpaceStatus" */
+export type ContentSpaceStatus_Mutation_Response = {
+  __typename?: 'contentSpaceStatus_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int']['output'];
+  /** data from the rows affected by the mutation */
+  returning: Array<ContentSpaceStatus>;
+};
+
+/** on_conflict condition type for table "contentSpaceStatus" */
+export type ContentSpaceStatus_On_Conflict = {
+  constraint: ContentSpaceStatus_Constraint;
+  update_columns?: Array<ContentSpaceStatus_Update_Column>;
+  where?: InputMaybe<ContentSpaceStatus_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "contentSpaceStatus". */
+export type ContentSpaceStatus_Order_By = {
+  value?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: contentSpaceStatus */
+export type ContentSpaceStatus_Pk_Columns_Input = {
+  value: Scalars['String']['input'];
+};
+
+/** select columns of table "contentSpaceStatus" */
+export const enum ContentSpaceStatus_Select_Column {
+  /** column name */
+  Value = 'value'
+};
+
+/** input type for updating data in table "contentSpaceStatus" */
+export type ContentSpaceStatus_Set_Input = {
+  value?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** Streaming cursor of the table "contentSpaceStatus" */
+export type ContentSpaceStatus_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: ContentSpaceStatus_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type ContentSpaceStatus_Stream_Cursor_Value_Input = {
+  value?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** update columns of table "contentSpaceStatus" */
+export const enum ContentSpaceStatus_Update_Column {
+  /** column name */
+  Value = 'value'
+};
+
+export type ContentSpaceStatus_Updates = {
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<ContentSpaceStatus_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: ContentSpaceStatus_Bool_Exp;
+};
+
 /** Currencies code following the standard ISO 4217 (https://en.wikipedia.org/wiki/ISO_4217) */
 export type Currency = {
   __typename?: 'currency';
@@ -11312,6 +11651,14 @@ export type Mutation_Root = {
   delete_account?: Maybe<Account_Mutation_Response>;
   /** delete single row from the table: "account" */
   delete_account_by_pk?: Maybe<Account>;
+  /** delete data from the table: "contentSpaceParameters" */
+  delete_contentSpaceParameters?: Maybe<ContentSpaceParameters_Mutation_Response>;
+  /** delete single row from the table: "contentSpaceParameters" */
+  delete_contentSpaceParameters_by_pk?: Maybe<ContentSpaceParameters>;
+  /** delete data from the table: "contentSpaceStatus" */
+  delete_contentSpaceStatus?: Maybe<ContentSpaceStatus_Mutation_Response>;
+  /** delete single row from the table: "contentSpaceStatus" */
+  delete_contentSpaceStatus_by_pk?: Maybe<ContentSpaceStatus>;
   /** delete data from the table: "currency" */
   delete_currency?: Maybe<Currency_Mutation_Response>;
   /** delete single row from the table: "currency" */
@@ -11442,6 +11789,14 @@ export type Mutation_Root = {
   insert_account?: Maybe<Account_Mutation_Response>;
   /** insert a single row into the table: "account" */
   insert_account_one?: Maybe<Account>;
+  /** insert data into the table: "contentSpaceParameters" */
+  insert_contentSpaceParameters?: Maybe<ContentSpaceParameters_Mutation_Response>;
+  /** insert a single row into the table: "contentSpaceParameters" */
+  insert_contentSpaceParameters_one?: Maybe<ContentSpaceParameters>;
+  /** insert data into the table: "contentSpaceStatus" */
+  insert_contentSpaceStatus?: Maybe<ContentSpaceStatus_Mutation_Response>;
+  /** insert a single row into the table: "contentSpaceStatus" */
+  insert_contentSpaceStatus_one?: Maybe<ContentSpaceStatus>;
   /** insert data into the table: "currency" */
   insert_currency?: Maybe<Currency_Mutation_Response>;
   /** insert a single row into the table: "currency" */
@@ -11732,6 +12087,18 @@ export type Mutation_Root = {
   update_account_by_pk?: Maybe<Account>;
   /** update multiples rows of table: "account" */
   update_account_many?: Maybe<Array<Maybe<Account_Mutation_Response>>>;
+  /** update data of the table: "contentSpaceParameters" */
+  update_contentSpaceParameters?: Maybe<ContentSpaceParameters_Mutation_Response>;
+  /** update single row of the table: "contentSpaceParameters" */
+  update_contentSpaceParameters_by_pk?: Maybe<ContentSpaceParameters>;
+  /** update multiples rows of table: "contentSpaceParameters" */
+  update_contentSpaceParameters_many?: Maybe<Array<Maybe<ContentSpaceParameters_Mutation_Response>>>;
+  /** update data of the table: "contentSpaceStatus" */
+  update_contentSpaceStatus?: Maybe<ContentSpaceStatus_Mutation_Response>;
+  /** update single row of the table: "contentSpaceStatus" */
+  update_contentSpaceStatus_by_pk?: Maybe<ContentSpaceStatus>;
+  /** update multiples rows of table: "contentSpaceStatus" */
+  update_contentSpaceStatus_many?: Maybe<Array<Maybe<ContentSpaceStatus_Mutation_Response>>>;
   /** update data of the table: "currency" */
   update_currency?: Maybe<Currency_Mutation_Response>;
   /** update single row of the table: "currency" */
@@ -12173,6 +12540,30 @@ export type Mutation_RootDelete_Account_By_PkArgs = {
 
 
 /** mutation root */
+export type Mutation_RootDelete_ContentSpaceParametersArgs = {
+  where: ContentSpaceParameters_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_ContentSpaceParameters_By_PkArgs = {
+  id: Scalars['uuid']['input'];
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_ContentSpaceStatusArgs = {
+  where: ContentSpaceStatus_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_ContentSpaceStatus_By_PkArgs = {
+  value: Scalars['String']['input'];
+};
+
+
+/** mutation root */
 export type Mutation_RootDelete_CurrencyArgs = {
   where: Currency_Bool_Exp;
 };
@@ -12564,6 +12955,34 @@ export type Mutation_RootInsert_AccountArgs = {
 export type Mutation_RootInsert_Account_OneArgs = {
   object: Account_Insert_Input;
   on_conflict?: InputMaybe<Account_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_ContentSpaceParametersArgs = {
+  objects: Array<ContentSpaceParameters_Insert_Input>;
+  on_conflict?: InputMaybe<ContentSpaceParameters_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_ContentSpaceParameters_OneArgs = {
+  object: ContentSpaceParameters_Insert_Input;
+  on_conflict?: InputMaybe<ContentSpaceParameters_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_ContentSpaceStatusArgs = {
+  objects: Array<ContentSpaceStatus_Insert_Input>;
+  on_conflict?: InputMaybe<ContentSpaceStatus_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_ContentSpaceStatus_OneArgs = {
+  object: ContentSpaceStatus_Insert_Input;
+  on_conflict?: InputMaybe<ContentSpaceStatus_On_Conflict>;
 };
 
 
@@ -13865,6 +14284,46 @@ export type Mutation_RootUpdate_Account_By_PkArgs = {
 /** mutation root */
 export type Mutation_RootUpdate_Account_ManyArgs = {
   updates: Array<Account_Updates>;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_ContentSpaceParametersArgs = {
+  _set?: InputMaybe<ContentSpaceParameters_Set_Input>;
+  where: ContentSpaceParameters_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_ContentSpaceParameters_By_PkArgs = {
+  _set?: InputMaybe<ContentSpaceParameters_Set_Input>;
+  pk_columns: ContentSpaceParameters_Pk_Columns_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_ContentSpaceParameters_ManyArgs = {
+  updates: Array<ContentSpaceParameters_Updates>;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_ContentSpaceStatusArgs = {
+  _set?: InputMaybe<ContentSpaceStatus_Set_Input>;
+  where: ContentSpaceStatus_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_ContentSpaceStatus_By_PkArgs = {
+  _set?: InputMaybe<ContentSpaceStatus_Set_Input>;
+  pk_columns: ContentSpaceStatus_Pk_Columns_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_ContentSpaceStatus_ManyArgs = {
+  updates: Array<ContentSpaceStatus_Updates>;
 };
 
 
@@ -18144,6 +18603,18 @@ export type Query_Root = {
   assetsConnection: AssetConnection;
   /** Retrieve a single contentSpace */
   contentSpace?: Maybe<ContentSpace>;
+  /** fetch data from the table: "contentSpaceParameters" */
+  contentSpaceParameters: Array<ContentSpaceParameters>;
+  /** fetch aggregated fields from the table: "contentSpaceParameters" */
+  contentSpaceParameters_aggregate: ContentSpaceParameters_Aggregate;
+  /** fetch data from the table: "contentSpaceParameters" using primary key columns */
+  contentSpaceParameters_by_pk?: Maybe<ContentSpaceParameters>;
+  /** fetch data from the table: "contentSpaceStatus" */
+  contentSpaceStatus: Array<ContentSpaceStatus>;
+  /** fetch aggregated fields from the table: "contentSpaceStatus" */
+  contentSpaceStatus_aggregate: ContentSpaceStatus_Aggregate;
+  /** fetch data from the table: "contentSpaceStatus" using primary key columns */
+  contentSpaceStatus_by_pk?: Maybe<ContentSpaceStatus>;
   /** Retrieve document version */
   contentSpaceVersion?: Maybe<DocumentVersion>;
   /** Retrieve multiple contentSpaces */
@@ -18470,6 +18941,52 @@ export type Query_RootContentSpaceArgs = {
   locales?: Array<Locale>;
   stage?: Stage;
   where: ContentSpaceWhereUniqueInput;
+};
+
+
+export type Query_RootContentSpaceParametersArgs = {
+  distinct_on?: InputMaybe<Array<ContentSpaceParameters_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<ContentSpaceParameters_Order_By>>;
+  where?: InputMaybe<ContentSpaceParameters_Bool_Exp>;
+};
+
+
+export type Query_RootContentSpaceParameters_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<ContentSpaceParameters_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<ContentSpaceParameters_Order_By>>;
+  where?: InputMaybe<ContentSpaceParameters_Bool_Exp>;
+};
+
+
+export type Query_RootContentSpaceParameters_By_PkArgs = {
+  id: Scalars['uuid']['input'];
+};
+
+
+export type Query_RootContentSpaceStatusArgs = {
+  distinct_on?: InputMaybe<Array<ContentSpaceStatus_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<ContentSpaceStatus_Order_By>>;
+  where?: InputMaybe<ContentSpaceStatus_Bool_Exp>;
+};
+
+
+export type Query_RootContentSpaceStatus_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<ContentSpaceStatus_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<ContentSpaceStatus_Order_By>>;
+  where?: InputMaybe<ContentSpaceStatus_Bool_Exp>;
+};
+
+
+export type Query_RootContentSpaceStatus_By_PkArgs = {
+  value: Scalars['String']['input'];
 };
 
 
@@ -20557,6 +21074,22 @@ export type Subscription_Root = {
   account_by_pk?: Maybe<Account>;
   /** fetch data from the table in a streaming manner: "account" */
   account_stream: Array<Account>;
+  /** fetch data from the table: "contentSpaceParameters" */
+  contentSpaceParameters: Array<ContentSpaceParameters>;
+  /** fetch aggregated fields from the table: "contentSpaceParameters" */
+  contentSpaceParameters_aggregate: ContentSpaceParameters_Aggregate;
+  /** fetch data from the table: "contentSpaceParameters" using primary key columns */
+  contentSpaceParameters_by_pk?: Maybe<ContentSpaceParameters>;
+  /** fetch data from the table in a streaming manner: "contentSpaceParameters" */
+  contentSpaceParameters_stream: Array<ContentSpaceParameters>;
+  /** fetch data from the table: "contentSpaceStatus" */
+  contentSpaceStatus: Array<ContentSpaceStatus>;
+  /** fetch aggregated fields from the table: "contentSpaceStatus" */
+  contentSpaceStatus_aggregate: ContentSpaceStatus_Aggregate;
+  /** fetch data from the table: "contentSpaceStatus" using primary key columns */
+  contentSpaceStatus_by_pk?: Maybe<ContentSpaceStatus>;
+  /** fetch data from the table in a streaming manner: "contentSpaceStatus" */
+  contentSpaceStatus_stream: Array<ContentSpaceStatus>;
   /** fetch data from the table: "currency" */
   currency: Array<Currency>;
   /** fetch aggregated fields from the table: "currency" */
@@ -20841,6 +21374,66 @@ export type Subscription_RootAccount_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Account_Stream_Cursor_Input>>;
   where?: InputMaybe<Account_Bool_Exp>;
+};
+
+
+export type Subscription_RootContentSpaceParametersArgs = {
+  distinct_on?: InputMaybe<Array<ContentSpaceParameters_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<ContentSpaceParameters_Order_By>>;
+  where?: InputMaybe<ContentSpaceParameters_Bool_Exp>;
+};
+
+
+export type Subscription_RootContentSpaceParameters_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<ContentSpaceParameters_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<ContentSpaceParameters_Order_By>>;
+  where?: InputMaybe<ContentSpaceParameters_Bool_Exp>;
+};
+
+
+export type Subscription_RootContentSpaceParameters_By_PkArgs = {
+  id: Scalars['uuid']['input'];
+};
+
+
+export type Subscription_RootContentSpaceParameters_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<ContentSpaceParameters_Stream_Cursor_Input>>;
+  where?: InputMaybe<ContentSpaceParameters_Bool_Exp>;
+};
+
+
+export type Subscription_RootContentSpaceStatusArgs = {
+  distinct_on?: InputMaybe<Array<ContentSpaceStatus_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<ContentSpaceStatus_Order_By>>;
+  where?: InputMaybe<ContentSpaceStatus_Bool_Exp>;
+};
+
+
+export type Subscription_RootContentSpaceStatus_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<ContentSpaceStatus_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<ContentSpaceStatus_Order_By>>;
+  where?: InputMaybe<ContentSpaceStatus_Bool_Exp>;
+};
+
+
+export type Subscription_RootContentSpaceStatus_By_PkArgs = {
+  value: Scalars['String']['input'];
+};
+
+
+export type Subscription_RootContentSpaceStatus_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<ContentSpaceStatus_Stream_Cursor_Input>>;
+  where?: InputMaybe<ContentSpaceStatus_Bool_Exp>;
 };
 
 


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
- This PR focuses on creating a database model for content space parameters.
- New tables `contentSpaceParameters` and `contentSpaceStatus` are created in the database.
- New queries and mutation related to content space are added in GraphQL.
- New types for the queries and mutation are also added.
- Remote relationships are added to the `contentSpace` table to improve data fetching efficiency.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Added new queries and mutation for content space in GraphQL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/gql/admin/api/src/generated/index.ts
- Added `ContentSpaceFieldsFragmentDoc` for content space fields.
- Added queries `GetContentSpaceFromOrganizerIdTableDocument`, `<br>  ``GetContentSpaceWithEventPassesOrganizerDocument`.
- Added mutation `CreateContentSpaceParametersDocument`.
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/261/files#diff-a705910118ccb32a0fbdface4f59baf2452ffd8cdb25417f4774ef2c40fc5522">+73/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Added new types for content space related operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/gql/admin/types/src/generated/index.ts
- Added new types for content space related queries and mutation.
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/261/files#diff-4422451788e8d06758e06954bb63de4ec1cf3a7dc5ee511d19b332e4615b3270">+27/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>contentSpace.query.gql</strong><dd><code>Added new queries for fetching content space data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/gql/admin/api/src/queries/organizer/contentSpace/contentSpace.query.gql
- Added new queries `GetContentSpaceFromOrganizerIdTable` and <br>  `GetContentSpaceWithEventPassesOrganizer`.
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/261/files#diff-1279ee2bf51936497793d00b823db6e2d4b06555b1935fd65d942f3e28780888">+42/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ContentSpaceFields.fragment.gql</strong><dd><code>Added new fragment for content space fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/gql/admin/api/src/queries/organizer/contentSpace/ContentSpaceFields.fragment.gql
- Added fragment for `ContentSpace` fields.
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/261/files#diff-8cfc0fc127094404109b0185d1294c2405484135a4e4ea883e24b8cce380d2f6">+18/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>contentSpaceParameters.mutation.gql</strong><dd><code>Added new mutation for creating content space parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/gql/admin/api/src/queries/organizer/contentSpace/contentSpaceParameters.mutation.gql
- Added mutation to create content space parameters.
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/261/files#diff-0e518ef398dadb74a21697fe8a826a2d734d7a375e91efe463c9522d9714edcf">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Database</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>down.sql</strong><dd><code>Added down migration for content space related tables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hasura/app/migrations/default/1706105882414_contentSpaceParameters/down.sql
- Added down migration for `contentSpaceParameters` and <br>  `contentSpaceStatus` tables.
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/261/files#diff-76a17335828d15132871dc16af73fafcc20c1e7191962de9dc2eaa681aba27a0">+33/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>up.sql</strong><dd><code>Added up migration for content space related tables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hasura/app/migrations/default/1706105882414_contentSpaceParameters/up.sql
- Added up migration for `contentSpaceParameters` and <br>  `contentSpaceStatus` tables.
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/261/files#diff-24b63d94a2de99dec08cf349efbe8954ce3d685212f20705e23543b21c5dfe3c">+31/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>public_contentSpaceStatus.yaml</strong><dd><code>Created new enum table for content space status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hasura/app/metadata/databases/default/tables/public_contentSpaceStatus.yaml
- Created `contentSpaceStatus` table as an enum.
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/261/files#diff-2ab9e7fd3456ff151ca613365f14ae2ea52bddfcfd5d5410fffc9984e3092ff9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>remote_schemas.yaml</strong><dd><code>Added new relationship in remote schemas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hasura/app/metadata/remote_schemas.yaml
- Added relationship to `contentSpaceParameters` table in `ContentSpace` <br>  type.
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/261/files#diff-230a925bddfe241b86fb5caf677d2018aa78b56332c3fa1d2897c542dee420fa">+12/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>public_contentSpaceParameters.yaml</strong><dd><code>Added new remote relationship in content space parameters table</code>&nbsp; &nbsp; </dd></summary>
<hr>

hasura/app/metadata/databases/default/tables/public_contentSpaceParameters.yaml
- Added remote relationship to `contentSpace` table.
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/261/files#diff-a10b85773ab69f06b224b15561ff5548f35df09b7e2f16cba79bee7381d6a7ac">+15/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tables.yaml</strong><dd><code>Included new tables in tables.yaml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hasura/app/metadata/databases/default/tables/tables.yaml
- Included `contentSpaceParameters` and `contentSpaceStatus` tables in <br>  tables.yaml.
    </details>
  </td>
  <td><a href="https://github.com/Offline-Project/marketplace/pull/261/files#diff-64134afde1ae913fd3f24314e18179ae5e335be6b0ff79a3501bee617503e304">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
