### PR TITLE
✨ (globals.css): Add default font stack for improved cross-platform c…

### DIFF
--- a/apps/unlock/styles/globals.css
+++ b/apps/unlock/styles/globals.css
@@ -4,6 +4,11 @@
 
 @layer base {
   :root {
+    --default-font-stack: -apple-system, system-ui, BlinkMacSystemFont,
+      'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif,
+      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+      'Noto Color Emoji';
+
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
 
@@ -198,11 +203,12 @@
 
 body {
   @apply h-full antialiased;
+  font-family: var(--font-family, var(--default-font-stack));
 }
 
 .off-iframe {
   @apply antialiased;
-  font-family: var(--font-family);
+  font-family: var(--font-family, var(--default-font-stack));
 }
 
 body,

--- a/libs/features/unlock/shopify/src/lib/OffKeyAuth/OffKeyAuthSignIn.tsx
+++ b/libs/features/unlock/shopify/src/lib/OffKeyAuth/OffKeyAuthSignIn.tsx
@@ -57,14 +57,11 @@ export function OffKeyAuthSignIn({
           walletAddress: existingWallet,
         })
       }
-      isLoading={isConnecting}
     >
-      {!isConnecting && (
-        <ProfileAvatar
-          user={{ id: '', address: existingWallet }}
-          className="my-1 size-8 md:size-8"
-        />
-      )}
+      <ProfileAvatar
+        user={{ id: '', address: existingWallet }}
+        className="my-1 size-8 md:size-8"
+      />
       <span>{t('sign-in')}</span>
     </Button>
   );


### PR DESCRIPTION
## **User description**
…onsistency

♻️ (OffKeyAuthSignIn.tsx): Simplify rendering logic by always displaying ProfileAvatar, removing conditional based on isConnecting state


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Introduced a new CSS variable `--default-font-stack` in `globals.css` for improved cross-platform font consistency.
- Updated `OffKeyAuthSignIn.tsx` to always display `ProfileAvatar`, enhancing UI consistency by removing conditional rendering.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>OffKeyAuthSignIn.tsx</strong><dd><code>Simplify OffKeyAuthSignIn Rendering Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/features/unlock/shopify/src/lib/OffKeyAuth/OffKeyAuthSignIn.tsx
<li>Simplified rendering logic by always displaying <code>ProfileAvatar</code>, <br>removing conditional rendering based on <code>isConnecting</code> state.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OfflineHQ/marketplace/pull/298/files#diff-a7a38c4ba86bbda1719d0fc1a196c2a6324076a0f3036bf2acb6e8612e42f923">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>globals.css</strong><dd><code>Add Default Font Stack for Cross-Platform Consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/unlock/styles/globals.css
<li>Introduced <code>--default-font-stack</code> variable for improved font consistency <br>across platforms.<br> <li> Applied the new default font stack to the <code>body</code> and <code>.off-iframe</code> <br>elements.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OfflineHQ/marketplace/pull/298/files#diff-8f887bd22dae65282c42bb406f58fbc6cc0dd9bc0e4789a4317e36b349e2ef02">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

